### PR TITLE
fix for add_row() test that did not revert changes to pre-test state

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -304,6 +304,9 @@ class WorksheetTest(GspreadTest):
         read_values = self.sheet.row_values(self.sheet.row_count)
         self.assertEqual(values, read_values)
 
+        # undo the appending and resizing
+        self.sheet.resize(num_rows, num_cols)
+
 
 class CellTest(GspreadTest):
     """Test for gspread.Cell."""


### PR DESCRIPTION
The test for add_row() does not revert changes to the pre-test state.

Reproducing the bug consists of running twice in succession the following test:

$ nosetests -x -s tests/test.py:WorksheetTest.test_properties

It should always fail the second time, since the test spreadsheet has now one line and four columns more than before.

Patch attached. 
