### PR TITLE
Add support for tox testrunner in response to klaszlo's issue #29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 tests/tests.config
+
+# tox testrunner support
+.tox/
+gspread.egg-info/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py25,py27,py32
+
+[testenv]
+deps = nose
+commands = nosetests []


### PR DESCRIPTION
The tox testrunner (http://tox.testrun.org/) plus the added tox.ini allow us to run tests against Python's versions 2.5, 2.7 and 3.2.

This is in preparation of fixing klaszlo's issue #29 (add Python2.5 support), but it's also a nice way of testing that any fixes or new features don't introduce regressions in any of the supported versions of Python.
