### PR TITLE
Python 2.5 now passes all tests, but 3.2 support is broken

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -85,7 +85,7 @@ class Client(object):
             auth_header = "GoogleLogin auth=%s" % token
             self.session.add_header('Authorization', auth_header)
 
-        except HTTPError as ex:
+        except HTTPError, ex:
             if ex.code == 403:
                 content = ex.read().decode()
                 if content.strip() == 'Error=BadAuthentication':
@@ -230,7 +230,7 @@ class Client(object):
 
         try:
             r = self.session.put(url, data, headers=headers)
-        except HTTPError as ex:
+        except HTTPError, ex:
             if ex.code == 403:
                 message = ex.read().decode()
                 raise UpdateCellError(message)
@@ -245,7 +245,7 @@ class Client(object):
 
         try:
             r = self.session.post(url, data, headers=headers)
-        except HTTPError as ex:
+        except HTTPError, ex:
             message = ex.read().decode()
             raise RequestError(message)
 

--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -55,8 +55,12 @@ class HTTPSession(object):
 
         try:
             return request.urlopen(req)
-        except HTTPError as e:
-            raise e
+        except HTTPError, e:
+            # crazy Python 2.5 urllib2 returns 201 responses as errors
+            if str(e) == 'HTTP Error 201: Created':
+                return e
+            else:
+                raise e
 
     def get(self, url, **kwargs):
         return self.request('get', url, **kwargs)

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -270,7 +270,8 @@ class Worksheet(object):
         <Cell R1C1 "I'm cell A1">
 
         """
-        return self.cell(*(self.get_int_addr(label)))
+        row, col = self.get_int_addr(label)
+        return self.cell(row, col)
 
     def cell(self, row, col):
         """Returns an instance of a :class:`Cell` positioned in `row`
@@ -311,7 +312,7 @@ class Worksheet(object):
             row[cell.col] = cell.value
 
         # we return a whole rectangular region worth of cells, including empties
-        all_row_keys = chain.from_iterable(row.keys() for row in rows.values())
+        all_row_keys = chain(*(row.keys() for row in rows.values()))
         rect_cols = range(1, max(all_row_keys)+1)
         rect_rows = range(1, max(rows.keys())+1)
 
@@ -385,7 +386,8 @@ class Worksheet(object):
         <Cell R1C1 "I'm cell A1">
 
         """
-        return self.update_cell(*(self.get_int_addr(label)), val=val)
+        row, col = self.get_int_addr(label)
+        return self.update_cell(row, col, val=val)
 
     def update_cell(self, row, col, val):
         """Sets the new value to a cell.
@@ -491,8 +493,8 @@ class Worksheet(object):
             self.resize(cols=data_width)
 
         cell_list = []
-        for i, value in enumerate(values, start=1):
-            cell = self.cell(new_row, i)
+        for i, value in enumerate(values):
+            cell = self.cell(new_row, i+1)
             cell.value = value
             cell_list.append(cell)
 

--- a/gspread/urls.py
+++ b/gspread/urls.py
@@ -45,6 +45,14 @@ _field_re = re.compile(r'{(\w+)}')
 def _extract_fields(patternstr):
     return _field_re.findall(patternstr)
 
+def format(urlpattern, params):
+    fragment = urlpattern
+    fields = _extract_fields(urlpattern)
+    for field in fields:
+        _field_re = re.compile(r'{%s}' % (re.escape(field)))
+        fragment = _field_re.sub(params[field], fragment)
+    return fragment
+
 def construct_url(feedtype=None,
                   obj=None,
                   visibility='private',
@@ -60,7 +68,7 @@ def construct_url(feedtype=None,
         if fields is None:
             fields = _extract_fields(urlpattern)
             _fields_cache[feedtype] = fields
-    except KeyError as e:
+    except KeyError, e:
         raise UnsupportedFeedTypeError(e)
 
     obj_fields = obj.get_id_fields() if obj is not None else {}
@@ -77,6 +85,6 @@ def construct_url(feedtype=None,
 
     try:
         return '%s%s' % (SPREADSHEETS_FEED_URL,
-                         urlpattern.format(**params))
-    except KeyError as e:
+                         format(urlpattern, params))
+    except KeyError, e:
         raise UrlParameterMissing(e)

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -10,6 +10,12 @@ This module contains utility functions.
 
 from xml.etree import ElementTree
 
+# backporting next() necessary for Python 2.5 support
+try:
+    next
+except NameError:
+    def next(obj):
+        return obj.next()
 
 def finditem(func, seq):
     """Finds and returns first item in iterable for which func(item) is True.

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ def read(filename):
 description = 'Google Spreadsheets Python library'
 
 long_description = """
-{index}
-
 License
 -------
 MIT
@@ -24,7 +22,7 @@ Download
 ========
 """
 
-long_description = long_description.lstrip("\n").format(index=read('docs/index.txt'))
+long_description = read('docs/index.txt') + long_description
 
 setup(
     name='gspread',

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,6 +8,7 @@ import hashlib
 import unittest
 import ConfigParser
 import itertools
+import datetime
 
 import gspread
 
@@ -80,6 +81,15 @@ class SpreadsheetTest(GspreadTest):
         sheet = self.spreadsheet.worksheet(sheet_title)
         self.assertTrue(isinstance(sheet, gspread.Worksheet))
 
+    def test_add_worksheet(self):
+        # make a new, clean worksheet
+        now = str(datetime.time())
+        sheet_name = "add_worksheet_test" + now
+        self.spreadsheet.add_worksheet(sheet_name, 10, 5)
+        sheet = self.spreadsheet.worksheet(sheet_name)
+        self.assertTrue(isinstance(sheet, gspread.Worksheet))
+
+        # TODO(candeira) delete sheet after test. Has to wait for oauth.
 
 class WorksheetTest(GspreadTest):
     """Test for gspread.Worksheet."""
@@ -267,8 +277,8 @@ class WorksheetTest(GspreadTest):
     def test_get_all_records(self):
         # make a new, clean worksheet
         # same as for test_all_values, find a way to refactor it
-        self.spreadsheet.add_worksheet('get_all_values_test', 10, 5)
-        sheet = self.spreadsheet.worksheet('get_all_values_test')
+        self.spreadsheet.add_worksheet('get_all_records_test', 10, 5)
+        sheet = self.spreadsheet.worksheet('get_all_records_test')
 
         # put in new values, made from three lists
         rows = [["A1","B1", "", "D1"],


### PR DESCRIPTION
Hi Anton,

This is more of a code review than a real pull request. gspread now passes all tests on Python 2.5, including a new one I had to add because Python 2.5 urllib2 is insane, and raises exceptions to inform you of success codes if they aren't 200. So `201 Created` translates to `raise Boom('in your face')`.

Support for 3.x is now broken. Since the tests didn't run all that well on 3.x anyway (choking on the Python 2.xthe literal syntax for long integers, for instance), my plan is to reinstate support for 3.x by enabling automatic source conversion with 2to3. If I get it working, would you fold this branch into your master?
