### PR TITLE
Use httplib instead of urllib2

### DIFF
--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -76,9 +76,3 @@ class HTTPSession(object):
 
     def add_header(self, name, value):
         self.headers[name] = value
-
-    def close(self):
-        try:
-            self.connection.close()
-        except:
-            print 'Connection could not be closed.'


### PR DESCRIPTION
Hi,

thanks for your library. it was really useful. I noticed that the implementation on top of urllib2 renegotiates a ssl handshake every time a cell is updated. I sit behind a lot of proxies and had a huge number of cell updates so this was really slow. Due to your interface design, it was really easy to port the HttpSession to httplib. If you want this, please go ahead and merge. 

I wasn't quite sure about the exception handling as these sort of leak internals out of the base class. If you want me to rework this piece, just tell me. Also I wonder how this will work with python 1 if you want to support it.

All right have a great night,
Valentin
