### PR TITLE
Adding documentation about two factor authorization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Features:
 * Independent of Google Data Python client library.
 * Python 3 support.
 
+### Two Factor Authorization
+
+At this time gspread will not work if you have Two Factor Authorization turned on for your account.
+
 ## Basic usage
 
 ```python
@@ -69,7 +73,7 @@ values_list = worksheet.row_values(1)
 values_list = worksheet.col_values(1)
 ```
 
-### Getting all values from a worksheet as a list of lists 
+### Getting all values from a worksheet as a list of lists
 
 ```python
 list_of_lists = worksheet.get_all_values()


### PR DESCRIPTION
Gspread doesn't work if you have two factor authorization turned on for your account. I added a line to the readme indicating that.
