### PR TITLE
Adds an "authorize()" method for OAuth as alternative to "login()"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.pyc
+*.py~
 tests/tests.config
+build/
+dist/
 
 # tox testrunner support
 .tox/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ import gspread
 # Login with your Google account
 gc = gspread.login('thedude@abid.es', 'password')
 
+# Connect with your Google OAuth2 credentials as described in [Accessing a Google API](https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Calling_a_Google_API) and [Refreshing an Access Token](https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Refreshing_a_Token)
+access_token = 'ya29.1.AADtN_Wkaip*************************lDBvFqYBYa6nSFHW1C4Vgc'
+refresh_token = '1/Sfw************************************xq1Y'
+client_secret = 'p3*******************zsh'
+client_id = '429*******699.apps.googleusercontent.com'
+
+key_ring = {}
+key_ring['grant_type'] = 'refresh_token'
+key_ring['refresh_token'] = refresh_token
+key_ring['client_secret'] = client_secret
+key_ring['client_id'] = client_id
+
+gc = gspread.authorize(access_token, key_ring)
+
 # Open a worksheet from spreadsheet with one shot
 wks = gc.open("Where is the money Lebowski?").sheet1
 
@@ -154,11 +168,16 @@ worksheet.update_cells(cell_list)
 
 ### Two Factor Authorization
 
-In case your Google Account protected with [Two Factor Authorization](http://support.google.com/accounts/bin/answer.py?hl=en&answer=180744), 
+If your Google Account is protected with [Two Factor Authorization](http://support.google.com/accounts/bin/answer.py?hl=en&answer=180744), 
 you have to create [an application-specific password](https://accounts.google.com/b/0/IssuedAuthSubTokens?hl=en_GB) and use your email
 to login as usual.
 
 Otherwise you will get an `AuthenticationError: Unable to authenticate. 403 code` when trying to login.
+
+### OAuth2 authorization
+
+For more detailed help, refer to the Wiki pages for using the [older style Google API Console](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.#wiki-authenticationOld) or the 
+[newer style Google API Console](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.#wiki-authenticationNew) if you prefer.  When you know which spreadsheet you want to access, and have obtained your "Client Id" and "Client Secret", get an access token following [these steps](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.#wiki-authorizationAccess).  If you will be working with the spreadsheet for many hours, days or even months, you will prefer to get an access token and a refresh token following [these steps](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.#wiki-authorizationRefresh).
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ easy_install gspread
     ```sh
     nosetests
     ```
+    
+Detailed step-by-step instructions for installation and test are available in the Wiki:
+ - [Installation and test procedure](https://github.com/FleetingClouds/gspread/wiki/Installation-and-test-procedure)
+ - [How to get, use and refresh OAuth access tokens for gspread.](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.)
 
 ## Suggestions & Code Contribution
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,31 @@ Features:
 
 ## Basic Usage
 
+### Username and password authentication
+
 ```python
 import gspread
 
 # Login with your Google account
 gc = gspread.login('thedude@abid.es', 'password')
 
-# Connect with your Google OAuth2 credentials as described in [Accessing a Google API](https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Calling_a_Google_API) and [Refreshing an Access Token](https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Refreshing_a_Token)
+# Open a worksheet from spreadsheet with one shot
+wks = gc.open("Where is the money Lebowski?").sheet1
+
+wks.update_acell('B2', "it's down there somewhere, let me take another look.")
+
+# Fetch a cell range
+cell_list = wks.range('A1:B7')
+```
+
+### OAuth authentication
+
+ As described in [Accessing a Google API](https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Calling_a_Google_API) and [Refreshing an Access Token](https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Refreshing_a_Token)
+ 
+```python
+import gspread
+
+# Connect with your Google OAuth2 credentials
 access_token = 'ya29.1.AADtN_Wkaip*************************lDBvFqYBYa6nSFHW1C4Vgc'
 refresh_token = '1/Sfw************************************xq1Y'
 client_secret = 'p3*******************zsh'

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -11,7 +11,7 @@ Google Spreadsheets client library.
 __version__ = '0.1.0'
 __author__ = 'Anton Burnashev'
 
-from .client import Client, login
+from .client import Client, login, authorize
 from .models import Spreadsheet, Worksheet, Cell
 from .exceptions import (GSpreadException, AuthenticationError,
                          SpreadsheetNotFound, NoValidUrlKeyFound,

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -47,7 +47,7 @@ class Client(object):
     >>>
 
     """
-    def __init__(self, auth, http_session=None):
+    def __init__(self, auth=None, http_session=None):
         self.auth = auth
 
         if not http_session:
@@ -103,6 +103,10 @@ class Client(object):
             else:
                 raise AuthenticationError(
                     "Unable to authenticate. %s code" % ex.code)
+
+    def oauth2_authorize(self, access_token):
+        auth_header = "Bearer %s" % access_token
+        self.session.add_header('Authorization', auth_header)
 
     def open(self, title):
         """Opens a spreadsheet, returning a :class:`~gspread.Spreadsheet` instance.
@@ -283,4 +287,10 @@ def login(email, password):
     """
     client = Client(auth=(email, password))
     client.login()
+    return client
+
+
+def authorize(access_token):
+    client = Client()
+    client.oauth2_authorize(access_token)
     return client

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -104,9 +104,10 @@ class Client(object):
                 raise AuthenticationError(
                     "Unable to authenticate. %s code" % ex.code)
 
-    def oauth2_authorize(self, access_token):
+    def oauth2_authorize(self, access_token, credentials):
         auth_header = "Bearer %s" % access_token
         self.session.add_header('Authorization', auth_header)
+        self.session.keep_credentials(credentials)
 
     def open(self, title):
         """Opens a spreadsheet, returning a :class:`~gspread.Spreadsheet` instance.
@@ -290,7 +291,19 @@ def login(email, password):
     return client
 
 
-def authorize(access_token):
+def authorize(access_token, credentials):
+    """Connect to Google API using OAuth2 credentials.
+
+    This is a shortcut function which instantiates :class:`Client`
+
+    NOTE : does NOT connect immediately!
+      - invalid credentials will cause failure on first use.
+
+    Expired access token will be refreshed if all other credentials are valid.
+
+    :returns: :class: `Client` instance.
+
+    """
     client = Client()
-    client.oauth2_authorize(access_token)
+    client.oauth2_authorize(access_token, credentials)
     return client

--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -133,10 +133,24 @@ class HTTPSession(object):
         self.headers[name] = value
 
     def keep_credentials(self, credentials):
+
+        '''
+        Expects a dict of credentials prepared as follows:
+
+        credentials['grant_type'] = 'refresh_token'
+        credentials['refresh_token'] = refresh_token
+        credentials['client_secret'] = client_secret
+        credentials['client_id'] = client_id
+        '''
         self.credentials = credentials
 
     def refresh_authorization(self):
 
+        '''
+        Performs a token refresh cycle as described here :
+           https://developers.google.com/youtube/v3/guides/authentication#OAuth2_Refreshing_a_Token
+           
+        '''
         parms = urlencode(self.credentials)
         req_hdrs = {'Content-Type': 'application/x-www-form-urlencoded'}
         url = urlparse(GOOGLE_OAUTH_TOKEN_REFRESH_URL).netloc

--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -27,7 +27,15 @@ except NameError:
 
 
 GOOGLE_OAUTH_TOKEN_REFRESH_URL = "https://accounts.google.com/o/oauth2/token"
-GOOGLEZ_TOKEN_EXPIRY_PHRASE = "token expired"
+
+GOOGLEZ_ERROR_REASONS = [
+          "token expired"
+        , "token invalid"
+        , "¿reason?"
+        , "¿reason?"
+        , "¿reason?"
+    ]
+
 DELAY_BETWEEN_REFRESH_ATTEMPTS = 5 # seconds
 NUMBER_OF_REFRESH_ATTEMPTS = 5
 
@@ -91,7 +99,7 @@ class HTTPSession(object):
             return response
 
         # print "Status : {}. Reason : {}.".format(response.status, response.reason)
-        if GOOGLEZ_TOKEN_EXPIRY_PHRASE not in response.reason:
+        if not self.gone_stale(response):
                 raise HTTPError(response)
 
         # print "Force replacement of stored connection : {}://{}".format(uri.scheme, uri.netloc)
@@ -131,6 +139,14 @@ class HTTPSession(object):
 
     def add_header(self, name, value):
         self.headers[name] = value
+
+    def gone_stale(self, response):
+        theReason = response.reason.lower()
+        for aReason in GOOGLEZ_ERROR_REASONS:  
+            if aReason in theReason:
+                return True
+        return False
+
 
     def keep_credentials(self, credentials):
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -268,11 +268,13 @@ class Worksheet(object):
             raise IncorrectCellLabel('(%s, %s)' % (row, col))
 
         div = col
-        column_label = str()
+        column_label = ''
 
         while div:
             (div, mod) = divmod(div, 26)
-            mod=26 if mod==0 else mod
+            if mod == 0:
+                 mod = 26
+                 div -= 1
             column_label = chr(mod + self._MAGIC_NUMBER) + column_label
 
         label = '%s%s' % (column_label, row)

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -46,6 +46,7 @@ except ImportError :
 
 import os, sys, argparse, json, datetime, smtplib, base64, urllib2, time
 from pprint import pprint
+from progressbar import *
 
 try:
     from oauth2client.client import OAuth2WebServerFlow
@@ -64,12 +65,15 @@ class NameSpace(object):
     
 
 
-def third_person_auth(google_project_client_id, google_project_client_secret, client_email, end_user_email):
-    smtp_credentials = prep_smtp(client_email, google_project_client_id, google_project_client_secret, True)
-    print 'Got SMTP creds;\n\n{}'.format(smtp_credentials)
+def third_person_auth(credentials):
+    smtp_credentials = prep_smtp(credentials, True)
+    # print 'Got SMTP creds;\n\n{}'.format(smtp_credentials)
     
+    credentials.smtp_access_token = smtp_credentials['access_token']
+    credentials.smtp_refresh_token = smtp_credentials['refresh_token']
+
     data = {}
-    data['client_id'] = google_project_client_id # 	the client_id obtained from the APIs Console 	Indicates the client that is making the request. The value passed in this parameter must exactly match the value shown in the APIs Console.
+    data['client_id'] = credentials.google_project_client_id # 	the client_id obtained from the APIs Console 	Indicates the client that is making the request. The value passed in this parameter must exactly match the value shown in the APIs Console.
     data['scope'] = SCOPE  # Indicates the Google API access your application is requesting. The values passed in this parameter inform the consent page shown to the user. There is an inverse relationship between the number of permissions requested and the likelihood of obtaining user consent.
     
     url = 'https://accounts.google.com/o/oauth2/device/code'
@@ -80,83 +84,59 @@ def third_person_auth(google_project_client_id, google_project_client_secret, cl
     theJSON = json.loads(urllib2.urlopen(request).read())
 #    print 'Response as json : {}.'.format(theJSON)
 
-    verification_url = theJSON['verification_url']
-    user_code = theJSON['user_code']
-    expiry = int(theJSON['expires_in'])
-    device_code = theJSON['device_code']
+    credentials.verification_url = theJSON['verification_url']
+    credentials.user_code = theJSON['user_code']
+    credentials.expiry = int(theJSON['expires_in'])
+    credentials.device_code = theJSON['device_code']
     
-    subject = '%s wants permission to access your Google Spreadheets with "gspread".' % client_email
-    text = 'To give {} access to your spreadsheets, please copy this code [ {} ] to your clipboard, turn to {} and enter it in the field provided. You have {} minutes to do so.'.format(client_email, user_code, verification_url, expiry / 60)
+    credentials.subject = 'Requesting permission for remote access your Google Spreadheets.'
+    credentials.text = 'To give {} access to your spreadsheets, please copy this code [ {} ] to your clipboard, turn to {} and enter it in the field provided. You have {} minutes to do so.'.format(credentials.client_email, credentials.user_code, credentials.verification_url, credentials.expiry / 60)
     
-    req = {}
-    req['sat'] = smtp_credentials['access_token']
-    req['srt'] = smtp_credentials['refresh_token']
-    req['user'] = end_user_email
-    req['text'] = text
-    req['expiry'] = expiry
-    req['subject'] = subject
-    req['client_id'] = google_project_client_id
-    req['user_code'] = user_code
-    req['device_code'] = device_code
-    req['client_email'] = client_email
-    req['client_secret'] = google_project_client_secret
-    req['verification_url'] = verification_url
-
-    print ' ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..    '
-    pretty (req)
-    print ' ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..    '
-
     sending = True
     while sending :
         try :
         
-            request_approval(req)
+            request_approval(credentials)
             sending = False
             
         except smtplib.SMTPSenderRefused as sr :
 
             if sr[0] == 530 :
-                client_secret = req['client_secret']
-                smtp_refresh_token = req['srt']
                 if 'Authentication Required' in sr[1] :
 #                    print "  *    *   Do we get an 'invalid grant' error now ?   *    *    * "
                     pass
                     
-#                print 'Refresh required: %s ' % smtp_refresh_token
-#                print 'Client ID: %s, Secret: %s ' % (theCurrentOAuthClient, client_secret)
+                print 'Refresh required: %s ' % credentials.smtp_refresh_token
+                print 'Client ID: %s, Secret: %s ' % (credentials.google_project_client_id, credentials.google_project_client_secret)
 
                 rslt = RefreshToken(
-                      req['client_id']
-                    , client_secret
-                    , smtp_refresh_token
+                      credentials.google_project_client_id
+                    , credentials.google_project_client_secret
+                    , credentials.smtp_refresh_token
                 )
+                print 'Result = {}'.format(rslt)
                 if 'error' in rslt :
-#                    close_store()
                     raise Exception("Cannot refresh invalid SMTP token. '%s' " % rslt['error'])
                     
-                req['sat'] = rslt['access_token']
-                print 'New SMTP token : %s' % req['sat']
+                credentials.smtp_access_token = rslt['access_token']
+                print 'New SMTP token : %s' % credentials.smtp_access_token
     
-    return NameSpace(getAsForDevices(req))
+    return getAsForDevices(credentials)
 
-def getAsForDevices(rq) :
+def getAsForDevices(credentials) :
     m = 'ForDevices'
 
-    client = rq['client_id']
-
-    # print 'Getting authorization for device for "%s"' % client
-
-    subject = '%s wants permission to access your Google Spreadheets with "gspread".' % rq['client_email']
+    subject = '%s wants permission to access your Google Spreadheets with "gspread".' % credentials.client_email
     
     print "\n\n* * * * *  You have to verify that you DO allow this software to open your Google document space."
-    print     '* * * * *  Please check your email at %s.' % rq['user']
+    print     '* * * * *  Please check your email at %s.' % credentials.end_user_email
     print     '* * * * *  The message "%s" contains further instructions for you.' % subject
 
     data = {}
 
-    data['client_id'] = client
-    data['client_secret'] = rq['client_secret']
-    data['code'] = rq['device_code']
+    data['client_id'] = credentials.google_project_client_id
+    data['client_secret'] = credentials.google_project_client_secret
+    data['code'] = credentials.device_code
     data['grant_type'] = 'http://oauth.net/grant_type/device/1.0'
     
     url = 'https://accounts.google.com/o/oauth2/token'
@@ -166,36 +146,57 @@ def getAsForDevices(rq) :
     request = urllib2.Request (url, parms)
 
     delay = 30
-    triesLimit = rq['expiry'] / delay
-    tries = triesLimit
+    triesLimit = credentials.expiry
+    print 'Trying to get tokens.'
+    
+    widgets = [Bar('>'), ' ', Timer(), ' ', ReverseBar('<')]
+    with ProgressBar(widgets=widgets, maxval=triesLimit) as progress:
+        for i in range(1, triesLimit, delay):
+
+
+            theJSON = json.loads(urllib2.urlopen(request).read())
+
+            if 'access_token' in theJSON :
+                progress.finish()
+
+#                print ' * * * Authorized ! * * * '
+                credentials.oauth_access_token = theJSON['access_token']
+                credentials.oauth_refresh_token = theJSON['refresh_token']
+
+                return credentials
+                
+            elif 'error' in theJSON :
+                time.sleep(delay)
+                progress.update(i)
+            else :
+                progress.finish()
+                print ' * * *  Uh oh ! * * * %s ' % theJSON
+
+    print "Too late.  You'll have to repeat it all."
+    exit(-1)    
+
+
+
+
+    
+    '''
     while tries > 0 :
     
         theJSON = json.loads(urllib2.urlopen(request).read())
-        print 'Response as json : {}.'.format(theJSON)
+        # print 'Response as json : {}.'.format(theJSON)
 
         if 'access_token' in theJSON :
             print ' * * * Authorized ! * * * '
-            '''
-            store[theCurrentEndUser][theCurrentOAuthClient].access_token = theJSON['access_token']
-            store[theCurrentEndUser][theCurrentOAuthClient].refresh_token = theJSON['refresh_token']
-            store[theCurrentEndUser][theCurrentOAuthClient].auth_method = m
-
-            reopen_store()
-
-            logging.debug(
-                    '==>\nAccess token : {}\nRefresh token : {}'.format(
-                        store[theCurrentEndUser][theCurrentOAuthClient].access_token
-                      , store[theCurrentEndUser][theCurrentOAuthClient].refresh_token
-                    )
-            )
-            '''
             
-            return theJSON
+            credentials.oauth_access_token = theJSON['access_token']
+            credentials.oauth_refresh_token = theJSON['refresh_token']
+
+            return credentials
             
         elif 'error' in theJSON :
             if tries < triesLimit :
                 time.sleep(delay)
-                print 'Trying again to get tokens.  {} tries remain.'.format(tries)
+                print 'Trying again to get tokens.  {} tries remain. ({})'.format(tries, theJSON['error'])
         else :
             print ' * * *  Uh oh ! * * * %s ' % theJSON
             
@@ -203,12 +204,12 @@ def getAsForDevices(rq) :
         
     print "Too late.  You'll have to repeat it all."
     exit(-1)    
-    
+    '''
 
-def first_person_auth(idClient, secret, manual=True):
+def first_person_auth(credentials, manual=True):
 
-    flow = OAuth2WebServerFlow(client_id=idClient,
-                               client_secret=secret,
+    flow = OAuth2WebServerFlow(client_id=credentials.google_project_client_id,
+                               client_secret=credentials.google_project_client_secret,
                                scope='https://spreadsheets.google.com/feeds https://docs.google.com/feeds',
                                redirect_uri='http://example.com/auth_return')
 
@@ -216,32 +217,34 @@ def first_person_auth(idClient, secret, manual=True):
 
     flags = NameSpace({'noauth_local_webserver': manual, 'auth_host_port' : [8080, 8090], 'auth_host_name' : 'localhost', 'logging_level' : POSITIONAL_WARNING})
 
-    return run_flow(flow, storage, flags)
+    rslt = run_flow(flow, storage, flags)
+    credentials.oauth_access_token = rslt.access_token
+    credentials.oauth_refresh_token = rslt.refresh_token
+    return credentials
     
-def prepare_result(idClient, secret, credentials):
+def prepare_result(credentials):
 
     print "\n =    =    =    =    =    =    =    =    =    =    =    =    =    =   "
-    print "\n\n Data for use in gspread 'nose' tests, in file test.config : "
+    print "\n\n Code fragment to use to configure the gspread 'nose' tests.  Paste into the file 'test.config' : "
     print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
     print ""
     print "auth_type: OAuth"    
     print ";"
-    print "; These three values are obligatory for OAuth access, optional for UID/pwd access"
-    print '; The "wizard" get_google_oauth2_creds.py will you guide through the necessary steps and provide the values to paste here.'
-    print "client_secret: {}".format(secret)
-    print "client_id: {}".format(idClient)
-    print "refresh_token: {}".format(credentials.refresh_token)
+    print "; These three values are obligatory for OAuth access, not required for UID/pwd access"
+    print "client_secret: {}".format(credentials.google_project_client_secret)
+    print "client_id: {}".format(credentials.google_project_client_id)
+    print "refresh_token: {}".format(credentials.oauth_refresh_token)
     print ""
     print "; This value is optional but will make the tests start sooner if the token is less than 60 minutes old."
-    print "access_token: {}".format(credentials.access_token)
+    print "access_token: {}".format(credentials.oauth_access_token)
     print ""
     print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
 
 
     creds_oa = open('creds_oa.py', 'w')
-    creds_oa.write("\nrefresh_token = '{}'".format(credentials.refresh_token))
-    creds_oa.write("\nclient_secret = '{}'".format(secret))
-    creds_oa.write("\nclient_id = '{}'".format(idClient))
+    creds_oa.write("\nrefresh_token = '{}'".format(credentials.oauth_refresh_token))
+    creds_oa.write("\nclient_secret = '{}'".format(credentials.google_project_client_secret))
+    creds_oa.write("\nclient_id = '{}'".format(credentials.google_project_client_id))
     creds_oa.write("\n#")
     creds_oa.write("\nkey_ring = {}")
     creds_oa.write("\nkey_ring['grant_type'] = 'refresh_token'")
@@ -249,13 +252,16 @@ def prepare_result(idClient, secret, credentials):
     creds_oa.write("\nkey_ring['client_secret'] = client_secret")
     creds_oa.write("\nkey_ring['client_id'] = client_id")
     creds_oa.write("\n#")
-    creds_oa.write("\naccess_token = '{}'".format(credentials.access_token))
+    creds_oa.write("\naccess_token = '{}'".format(credentials.oauth_access_token))
     creds_oa.write("\n#\n#")
     creds_oa.write("\ncredentials = {")
     creds_oa.write("\n      'cred_type': 'oauth'")
     creds_oa.write("\n    , 'key_ring': key_ring")
     creds_oa.write("\n    , 'access_token': access_token")
     creds_oa.write("\n}")
+    creds_oa.write("\n#")
+    creds_oa.write("\nsmtp_access_token = '{}'".format(credentials.smtp_access_token))
+    creds_oa.write("\nsmtp_refresh_token = '{}'".format(credentials.smtp_refresh_token))
     creds_oa.write("\n#")
 
     creds_oa.close()
@@ -269,7 +275,7 @@ def prepare_result(idClient, secret, credentials):
     qiktest.write("\nimport gspread")
     qiktest.write("\nfrom creds_oa import access_token, key_ring")
     qiktest.write("\n#")
-    qiktest.write("\naccess_token = '{}'".format(credentials.access_token))
+    qiktest.write("\naccess_token = '{}'".format(credentials.oauth_access_token))
     qiktest.write("\ngc = gspread.authorize(access_token, key_ring)")
     qiktest.write("\n#")
     qiktest.write("\nwkbk = gc.open_by_url('{}')".format(spreadsheet_url))
@@ -288,23 +294,23 @@ def prepare_result(idClient, secret, credentials):
     print "      $  python qiktest.py  ## or possibly just  ./qiktest.py\n\n\n"
 
 
-def prep_smtp(google_client_email, google_client_id, google_client_secret, test_mail = False) :
+def prep_smtp(credentials, test_mail = False) :
 
     expiry = ''    
     scope = 'https://mail.google.com/'
 
-    print "\n    Acting as : {}".format(google_client_id)
-    print "\n    To be able to request authorization from your users by email, you need to authorize this program to use Google's email resender via {}.".format(google_client_email)
+    print "\n    Acting as : {}".format(credentials.google_project_client_id)
+    print "\n    To be able to request authorization from your users by email, you need to authorize this program to use Google's email resender via {}.".format(credentials.client_email)
     print "    Visit this url and follow the directions:\n"
     print '  %s' % GeneratePermissionUrl(
-                                              google_client_id
+                                              credentials.google_project_client_id
                                             , scope
                                         )
     authorization_code = raw_input('\n\n    * * * Enter verification code: ')
 
     response = AuthorizeTokens  (
-                                      google_client_id
-                                    , google_client_secret
+                                      credentials.google_project_client_id
+                                    , credentials.google_project_client_secret
                                     , authorization_code
                                 )
     access_token = ''
@@ -321,10 +327,12 @@ def prep_smtp(google_client_email, google_client_id, google_client_secret, test_
         exit(-1)
     
     expiry = (datetime.datetime.now() + datetime.timedelta(0,response['expires_in'])).strftime('%Y-%m-%d %H:%M')
+    '''
     print '\nSuccess :'
     print ' - Access Token: = %s' % access_token
     print ' - Refresh Token: %s'% refresh_token
     print ' - Access Token expires at : %s' % expiry
+    '''
         
     smtp_conn = smtplib.SMTP('smtp.gmail.com', 587)
     smtp_conn.set_debuglevel(False)
@@ -333,49 +341,51 @@ def prep_smtp(google_client_email, google_client_id, google_client_secret, test_
             
     # Temporary token...
     auth_string = GenerateOAuth2String  (
-                                              google_client_email
+                                              credentials.client_email
                                             , access_token
                                             , base64_encode = False
                                         )
+    '''
     print ">>>>"
     print auth_string
     print ">>>>"
+    '''
     
     # Preparing test email envelope . . 
     title = 'Trash this email'
     body = 'Congratulations. You have fully enabled mail transfer through Google SMTP.'
     envelope = 'From: %s\nTo: %s\nSubject: %s\n\n%s' % (
-                  google_client_email
-                , google_client_email
+                  credentials.client_email
+                , credentials.client_email
                 , title
                 , body)
  
     if test_mail :
-        print ' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+        print ' ~~~~~~~~~~~~~~~~~  START TEST EMAIL  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
         print envelope
-        print ' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+        print ' ~~~~~~~~~~~~~~~~~   END TEST EMAIL   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
             
         try :
         
             smtp_conn.docmd('AUTH', 'XOAUTH2 ' + base64.b64encode(auth_string))
-            print 'Sending . . . '
-            smtp_conn.sendmail(google_client_email, google_client_email, envelope)
-            print '. . . sent!\n'
+            print 'Sending TEST . . . '
+            smtp_conn.sendmail(credentials.client_email, credentials.client_email, envelope)
+            print '. . . TEST sent!\n'
             
         except smtplib.SMTPSenderRefused as sr :
             if sr[0] == 530 :
                 print 'Refresh required: Using %s' % refresh_token
-                access_token = RefreshToken(google_client_id, google_project_client_secret, refresh_token)
+                access_token = RefreshToken(credentials.google_project_client_id, google_project_client_secret, refresh_token)
                 print 'New token : %s' % access_token
                 smtp_conn.docmd('AUTH', 'XOAUTH2 ' + base64.b64encode(auth_string))
                 
                 try :
-                        smtp_conn.sendmail(google_client_email, google_client_email, envelope)
+                        smtp_conn.sendmail(credentials.client_email, credentials.client_email, envelope)
                 except smtplib.SMTPSenderRefused as sr :
                     print sr
                     if sr[0] == 535 :
                         print 'The access token is correct. Maybe the user id is wrong?'
-                        print '¿¿ Are you sure that <[{0}]> authorized <[{0}]> ??'.format(google_client_email)
+                        print '¿¿ Are you sure that <[{0}]> authorized <[{0}]> ??'.format(credentials.client_email)
                         exit(-1)
 
 
@@ -391,23 +401,15 @@ def prep_smtp(google_client_email, google_client_id, google_client_secret, test_
     
     return {'access_token':access_token, 'refresh_token':refresh_token, 'expiry': expiry}
     
-def request_approval(args) :
-
-    client_id = args['client_id']
-    client_email = args['client_email']
-    client_secret = args['client_secret']
     
-#    if store[theCurrentOAuthClient].smtp_access_token is None :
-#        args = prep_smtp(args, test_mail = True)
-#        store[theCurrentOAuthClient].smtp_access_token = args['sat']
-#        store[theCurrentOAuthClient].smtp_refresh_token = args['srt']
-        
-        
+def request_approval(credentials) :
 
     # print "Temporary token using %s and %s ."   %  (client_email, store[theCurrentOAuthClient].smtp_access_token)
-    auth_string = GenerateOAuth2String(client_email, args['sat'])
+    auth_string = GenerateOAuth2String(credentials.client_email, credentials.smtp_access_token)
             
-    message = 'From: %s\nTo: %s\nSubject: %s\n\n%s' % (client_email, args['user'], args['subject'], args['text'])
+    message = 'From: %s\nTo: %s\nSubject: %s\n\n%s' % (
+           credentials.client_email, credentials.end_user_email, credentials.subject, credentials.text)
+           
 #    print message
 
     smtp_conn = smtplib.SMTP('smtp.gmail.com', 587)
@@ -416,9 +418,9 @@ def request_approval(args) :
     smtp_conn.starttls()
     
     smtp_conn.docmd('AUTH', 'XOAUTH2 ' + auth_string)
-    print 'Sending . . . '
-    smtp_conn.sendmail(client_email, args['user'], message)
-    print ' . . sent!'
+    print 'Sending permission request . . . '
+    smtp_conn.sendmail(credentials.client_email, credentials.end_user_email, message)
+    print ' . . permission request sent!'
     
     smtp_conn.close()
 
@@ -449,10 +451,30 @@ if __name__ == '__main__':
         if f.endswith('.json'):
             cnt += 1;
             json_files.append(f)
-            
+        
     theFile = None
-    google_project_client_id = None
-    google_project_client_secret = None
+    
+    credentials = NameSpace(
+            {
+                  'text': ''
+                , 'expiry': ''
+                , 'subject': ''
+                , 'user_code': ''
+                , 'device_code': ''
+                , 'client_email': ''
+                , 'end_user_email': ''
+                , 'verification_url': ''
+                , 'smtp_access_token': ''
+                , 'smtp_refresh_token': ''
+                , 'oauth_access_token': ''
+                , 'oauth_refresh_token': ''
+                , 'google_project_client_id': ''
+                , 'google_project_client_secret': ''
+            })
+    print credentials.text
+    
+    
+    
     if cnt < 1:
         print '\n\nCould not find exactly one (1) expected json file (named like "client_secret_*.json" for example).'
         print 'You get such a file from https://cloud.google.com/console in the sub-section :'
@@ -460,8 +482,8 @@ if __name__ == '__main__':
         print '      - Credentials '
         print '          - Client ID for native application'
         print '             - [Download JSON]'
-        google_project_client_id = raw_input('\nPaste your Google "Client ID" : ')
-        google_project_client_secret = raw_input('\nPaste your Google "Client Secret" : ')
+        credentials.google_project_client_id = raw_input('\nPaste your Google "Client ID" : ')
+        credentials.google_project_client_secret = raw_input('\nPaste your Google "Client Secret" : ')
         
     else:
         theFile = json_files[0]
@@ -475,27 +497,31 @@ if __name__ == '__main__':
         
         json_data = open(theFile)
         oauth_creds = json.load(json_data)['installed']
-        google_project_client_id = oauth_creds['client_id']
-        google_project_client_secret = oauth_creds['client_secret']
+        credentials.google_project_client_id = oauth_creds['client_id']
+        credentials.google_project_client_secret = oauth_creds['client_secret']
         json_data.close()
+        
         print '\n The file "{}" contains :\n'.format(theFile)
-        print '               Client id : {}'.format(google_project_client_id)
-        print '               Client secret : {}\n'.format(google_project_client_secret)
+        print '               Client id : {}'.format(credentials.google_project_client_id)
+        print '               Client secret : {}\n'.format(credentials.google_project_client_secret)
 
-    personal = raw_input("\n\nDo you want to:\n\n (1) authorize just yourself in a browser or, \n (2) email an authorization request code to a user and ask them to tell Google to let you in?\n\n        (1 or 2)  : ") in ("1")
+    personal = False
+    # personal = raw_input("\n\nDo you want to:\n\n (1) authorize just yourself in a browser or, \n (2) email an authorization request code to a user and ask them to tell Google to let you in?\n\n        (1 or 2)  : ") in ("1")
     
     if personal:
         manual = raw_input("\n\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
-        credentials = first_person_auth(google_project_client_id, google_project_client_secret, manual)
+        credentials = first_person_auth(credentials, manual)
     else:
-        your_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
-        end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
+    
+        credentials.end_user_email = "martinhbramwell@gmail.com"
+        credentials.client_email = "mhb.warehouseman@gmail.com"
 
-        end_user_email = "mhb.warehouseman@gmail.com"
-        your_email = "alicia.factorepo@gmail.com"
-        credentials = third_person_auth(google_project_client_id, google_project_client_secret, your_email, end_user_email)
+        # credentials.client_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
+        # credentials.end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
+
+        credentials = third_person_auth(credentials)
         
-    print '\n Credentials are :\n{}'.format(credentials)
-    prepare_result(google_project_client_id, google_project_client_secret, credentials)
+#    print '\n Credentials are :\n{}'.format(credentials)
+    prepare_result(credentials)
     
     

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -52,15 +52,17 @@ def main(id, secret, manual=True):
     print "\n =    =    =    =    =    =    =    =    =    =    =    =    =    =   "
     print "\n\n Data for use in gspread 'nose' tests, in file test.config : "
     print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
-    print "[Google Account]"    
-    print "# auth_type: UIDPwd"    
+    print ""
     print "auth_type: OAuth"    
     print "#"
+    print "; These three values are obligatory for OAuth access, optional for UID/pwd access"
+    print '; The "wizard" get_google_oauth2_creds.py will you guide through the necessary steps and provide the values to paste here.'
     print "client_secret: {}".format(secret)
     print "client_id: {}".format(id)
-    print "access_token: {}".format(credentials.access_token)
     print "refresh_token: {}".format(credentials.refresh_token)
     print ""
+    print "; This value is optional but will make the tests start sooner if the token is less than 60 minutes old."
+    print "access_token: {}".format(credentials.access_token)
 
     qiktest = open('qiktest.py', 'w')
     qiktest.write("# - - - - - - - - - - - - - - - - - - - - - - - - - - -")

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -142,6 +142,6 @@ if __name__ == '__main__':
     print 'Identify the Google spreadsheet you want to use; use the full URL ("http://" etc, etc) '
     spreadsheet_url  = raw_input('Paste the full URL here : ')
     #
-    manual = raw_input("\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
+    manual = raw_input("\n\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
     
     main(client_id, client_secret, manual)

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -140,6 +140,6 @@ if __name__ == '__main__':
     print 'Identify the Google spreadsheet you want to use; use the full URL ("http://" etc, etc) '
     spreadsheet_url  = raw_input('Paste the full URL here : ')
     #
-    manual = raw_input("Shall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
+    manual = raw_input("\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
     
     main(client_id, client_secret, manual)

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -54,7 +54,7 @@ def main(id, secret, manual=True):
     print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
     print ""
     print "auth_type: OAuth"    
-    print "#"
+    print ";"
     print "; These three values are obligatory for OAuth access, optional for UID/pwd access"
     print '; The "wizard" get_google_oauth2_creds.py will you guide through the necessary steps and provide the values to paste here.'
     print "client_secret: {}".format(secret)
@@ -63,6 +63,8 @@ def main(id, secret, manual=True):
     print ""
     print "; This value is optional but will make the tests start sooner if the token is less than 60 minutes old."
     print "access_token: {}".format(credentials.access_token)
+    print ""
+    print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
 
     qiktest = open('qiktest.py', 'w')
     qiktest.write("# - - - - - - - - - - - - - - - - - - - - - - - - - - -")

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -49,8 +49,13 @@ def main(id, secret, manual=True):
 
     credentials = run_flow(flow, storage, flags)
 
-    print "\n\n"
-    print "[Spreadsheet]"
+    print "\n =    =    =    =    =    =    =    =    =    =    =    =    =    =   "
+    print "\n\n Data for use in gspread 'nose' tests, in file test.config : "
+    print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
+    print "[Google Account]"    
+    print "# auth_type: UIDPwd"    
+    print "auth_type: OAuth"    
+    print "#"
     print "client_secret: {}".format(secret)
     print "client_id: {}".format(id)
     print "access_token: {}".format(credentials.access_token)
@@ -66,7 +71,6 @@ def main(id, secret, manual=True):
     qiktest.write("\nclient_secret = '{}'".format(secret))
     qiktest.write("\nclient_id = '{}'".format(id))
     qiktest.write("\n#")
-    qiktest.write("\ncred_type = 'oauth'")
     qiktest.write("\nkey_ring = {}")
     qiktest.write("\nkey_ring['grant_type'] = 'refresh_token'")
     qiktest.write("\nkey_ring['refresh_token'] = refresh_token")
@@ -133,14 +137,9 @@ if __name__ == '__main__':
         print '               Client id : {}'.format(client_id)
         print '               Client secret : {}\n'.format(client_secret)
     
-#    spreadsheet_url  = raw_input('Paste the full URL, including the "http://" etc, etc, of the Google spreadsheet you want to use : ')
-#    local_app  = raw_input("Shall we try to open a page in your browser?  (Y/y)  : ")
-    spreadsheet_url  = 'https://docs.google.com/spreadsheet/ccc?key=0Asxy-TdDgbjidEstc3NQZWxMT0FYWWdabHFsMGlCcVE#gid=1'
-    local_app  = 'n'
-    
-
-
-    
-    manual = local_app not in "Yy"
+    print 'Identify the Google spreadsheet you want to use; use the full URL ("http://" etc, etc) '
+    spreadsheet_url  = raw_input('Paste the full URL here : ')
+    #
+    manual = raw_input("Shall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
     
     main(client_id, client_secret, manual)

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -65,8 +65,7 @@ class NameSpace(object):
 
 
 def third_person_auth(google_project_client_id, google_project_client_secret, client_email, end_user_email):
-    #smtp_credentials = prep_smtp(client_email, google_project_client_id, google_project_client_secret, True)
-    smtp_credentials = {'access_token': u'ya29.1.AADtN_UrB-lg5DHI6AcHM0A2YX--fEyfOi_xz4GiC-3qnY5i9UF9ps0k76nkbSi3xhHm1w', 'refresh_token': u'1/eUFgFZSSr3EvVpH2K46u33zMLHy2rauIhMeUbJCk-0k', 'expiry': '2014-01-22 14:15'}
+    smtp_credentials = prep_smtp(client_email, google_project_client_id, google_project_client_secret, True)
     print 'Got SMTP creds;\n\n{}'.format(smtp_credentials)
     
     data = {}
@@ -80,7 +79,6 @@ def third_person_auth(google_project_client_id, google_project_client_secret, cl
 
     theJSON = json.loads(urllib2.urlopen(request).read())
 #    print 'Response as json : {}.'.format(theJSON)
-#    logging.debug('Response as json : {}.'.format(theJSON))
 
     verification_url = theJSON['verification_url']
     user_code = theJSON['user_code']
@@ -484,15 +482,14 @@ if __name__ == '__main__':
         print '               Client id : {}'.format(google_project_client_id)
         print '               Client secret : {}\n'.format(google_project_client_secret)
 
-    personal = False
     personal = raw_input("\n\nDo you want to:\n\n (1) authorize just yourself in a browser or, \n (2) email an authorization request code to a user and ask them to tell Google to let you in?\n\n        (1 or 2)  : ") in ("1")
     
     if personal:
         manual = raw_input("\n\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
         credentials = first_person_auth(google_project_client_id, google_project_client_secret, manual)
     else:
-######        your_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
-######        end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
+        your_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
+        end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
 
         end_user_email = "mhb.warehouseman@gmail.com"
         your_email = "alicia.factorepo@gmail.com"

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -79,7 +79,14 @@ def main(id, secret, manual=True):
     creds_oa.write("\nkey_ring['client_id'] = client_id")
     creds_oa.write("\n#")
     creds_oa.write("\naccess_token = '{}'".format(credentials.access_token))
-    creds_oa.write("\n#\n")
+    creds_oa.write("\n#\n#")
+    creds_oa.write("\ncredentials = {")
+    creds_oa.write("\n      'cred_type': 'oauth'")
+    creds_oa.write("\n    , 'key_ring': key_ring")
+    creds_oa.write("\n    , 'access_token': access_token")
+    creds_oa.write("\n}")
+    creds_oa.write("\n#")
+
     creds_oa.close()
 
     qiktest = open('qiktest.py', 'w')

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+'''
+    This script will attempt to open your web browser,
+    perform OAuth 2 authentication and print out your full set
+    of OAuth credentials in the form of Python variable declarations.
+
+    It depends on Google's Python library: oauth2client.
+
+    To install that dependency from PyPI:
+
+    $ pip install oauth2client
+
+    Then run this script:
+
+    $ python get_google_oauth2_creds.py
+    
+    This is a combination of snippets from:
+    https://developers.google.com/api-client-library/python/guide/aaa_oauth
+
+'''
+import os, sys, argparse, json
+from pprint import pprint
+
+try:
+    from oauth2client.client import OAuth2WebServerFlow
+    from oauth2client.tools import run_flow
+    from oauth2client.file import Storage
+    from oauth2client.util import 	POSITIONAL_WARNING, POSITIONAL_EXCEPTION, POSITIONAL_IGNORE
+except ImportError:
+    print "ImportError: Please execute the following command (with root privileges):\npip install oauth2client"
+    exit(-1)
+
+class NameSpace(object):
+  def __init__(self, adict):
+    self.__dict__.update(adict)
+
+def main(id, secret, manual=True):
+
+    flow = OAuth2WebServerFlow(client_id=id,
+                               client_secret=secret,
+                               scope='https://spreadsheets.google.com/feeds https://docs.google.com/feeds',
+                               redirect_uri='http://example.com/auth_return')
+
+    storage = Storage('creds.data')
+
+    flags = NameSpace({'noauth_local_webserver': manual, 'auth_host_port' : [8080, 8090], 'auth_host_name' : 'localhost', 'logging_level' : POSITIONAL_WARNING})
+
+    credentials = run_flow(flow, storage, flags)
+
+    print "\n\n"
+    print "[Spreadsheet]"
+    print "client_secret: {}".format(secret)
+    print "client_id: {}".format(id)
+    print "access_token: {}".format(credentials.access_token)
+    print "refresh_token: {}".format(credentials.refresh_token)
+    print ""
+
+    qiktest = open('qiktest.py', 'w')
+    qiktest.write("# - - - - - - - - - - - - - - - - - - - - - - - - - - -")
+    qiktest.write("\n# -*- coding: utf-8 -*-")
+    qiktest.write("\nimport gspread")
+    qiktest.write("\n#")
+    qiktest.write("\nrefresh_token = '{}'".format(credentials.refresh_token))
+    qiktest.write("\nclient_secret = '{}'".format(secret))
+    qiktest.write("\nclient_id = '{}'".format(id))
+    qiktest.write("\n#")
+    qiktest.write("\ncred_type = 'oauth'")
+    qiktest.write("\nkey_ring = {}")
+    qiktest.write("\nkey_ring['grant_type'] = 'refresh_token'")
+    qiktest.write("\nkey_ring['refresh_token'] = refresh_token")
+    qiktest.write("\nkey_ring['client_secret'] = client_secret")
+    qiktest.write("\nkey_ring['client_id'] = client_id")
+    qiktest.write("\n#")
+    qiktest.write("\naccess_token = '{}'".format(credentials.access_token))
+    qiktest.write("\ngc = gspread.authorize(access_token, key_ring)")
+    qiktest.write("\n#")
+    qiktest.write("\nwkbk = gc.open_by_url('{}')".format(spreadsheet_url))
+    qiktest.write("\ncnt = 1")
+    qiktest.write("\nprint 'Found sheets:'")
+    qiktest.write("\nfor sheet in wkbk.worksheets():")
+    qiktest.write("\n    print ' - Sheet #{}: Id = {}  Title = {}'.format(cnt, sheet.id, sheet.title)")
+    qiktest.write("\n    cnt += 1")
+    qiktest.write("\n#")
+    qiktest.write("\n# - - - - - - - - - - - - - - - - - - - - - - - - - - -")
+    qiktest.close()
+    #
+    print "\n\n   A simple example file called qiktest.py was written to disk."
+    print "   It lists the names of the sheets in the target spreadsheet."
+    print "   Test it with:"
+    print "      $  python qiktest.py\n\n\n"
+
+if __name__ == '__main__':
+
+    json_files = []
+    files = [f for f in os.listdir('.') if os.path.isfile(f)]
+    cnt = 0;
+    for f in files:
+        if f.endswith('.json'):
+            cnt += 1;
+            json_files.append(f)
+            
+    theFile = None
+    client_id = None
+    client_secret = None
+    if cnt < 1:
+        print '\n\nCould not find exactly one (1) expected json file (named like "client_secret_*.json" for example).'
+        print 'You get such a file from https://cloud.google.com/console in the sub-section :'
+        print '   - APIs & auth '
+        print '      - Credentials '
+        print '          - Client ID for native application'
+        print '             - [Download JSON]\n\n'
+        client_id = raw_input('Paste your Google "Client ID" : ')
+        client_secret = raw_input('Paste your Google "Client Secret" : ')
+        
+    else:
+        theFile = json_files[0]
+        if cnt > 1:
+            print '\n\nPlease type the number of the json file that contains the credentials you want to try.'
+            cnt = 0
+            for jf in json_files:
+                cnt += 1;
+                print '{}) -- {}'.format(cnt, jf)
+            theFile = json_files[int(raw_input('Which? ')) - 1 ]
+        
+        json_data = open(theFile)
+        oauth_creds = json.load(json_data)['installed']
+        client_id = oauth_creds['client_id']
+        client_secret = oauth_creds['client_secret']
+        json_data.close()
+        print '\n The file "{}" contains :\n'.format(theFile)
+        print '               Client id : {}'.format(client_id)
+        print '               Client secret : {}\n'.format(client_secret)
+    
+#    spreadsheet_url  = raw_input('Paste the full URL, including the "http://" etc, etc, of the Google spreadsheet you want to use : ')
+#    local_app  = raw_input("Shall we try to open a page in your browser?  (Y/y)  : ")
+    spreadsheet_url  = 'https://docs.google.com/spreadsheet/ccc?key=0Asxy-TdDgbjidEstc3NQZWxMT0FYWWdabHFsMGlCcVE#gid=1'
+    local_app  = 'n'
+    
+
+
+    
+    manual = local_app not in "Yy"
+    
+    main(client_id, client_secret, manual)

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 '''

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -89,7 +89,7 @@ def third_person_auth(credentials):
     credentials.expiry = int(theJSON['expires_in'])
     credentials.device_code = theJSON['device_code']
     
-    credentials.subject = 'Requesting permission for remote access your Google Spreadheets.'
+    credentials.subject = 'Requesting permission for remote access to your Google Spreadheets.'
     credentials.text = 'To give {} access to your spreadsheets, please copy this code [ {} ] to your clipboard, turn to {} and enter it in the field provided. You have {} minutes to do so.'.format(credentials.client_email, credentials.user_code, credentials.verification_url, credentials.expiry / 60)
     
     sending = True
@@ -175,36 +175,6 @@ def getAsForDevices(credentials) :
     print "Too late.  You'll have to repeat it all."
     exit(-1)    
 
-
-
-
-    
-    '''
-    while tries > 0 :
-    
-        theJSON = json.loads(urllib2.urlopen(request).read())
-        # print 'Response as json : {}.'.format(theJSON)
-
-        if 'access_token' in theJSON :
-            print ' * * * Authorized ! * * * '
-            
-            credentials.oauth_access_token = theJSON['access_token']
-            credentials.oauth_refresh_token = theJSON['refresh_token']
-
-            return credentials
-            
-        elif 'error' in theJSON :
-            if tries < triesLimit :
-                time.sleep(delay)
-                print 'Trying again to get tokens.  {} tries remain. ({})'.format(tries, theJSON['error'])
-        else :
-            print ' * * *  Uh oh ! * * * %s ' % theJSON
-            
-        tries -= 1
-        
-    print "Too late.  You'll have to repeat it all."
-    exit(-1)    
-    '''
 
 def first_person_auth(credentials, manual=True):
 
@@ -323,7 +293,7 @@ def prep_smtp(credentials, test_mail = False) :
         print '\n\nServer reported   %s' % response
         print ' - Did you get the *latest* verification code?'
         print ' - Did you get all of it?'
-        print ' - Did you use exactly the right ID and Secret for "Client for Installed Applications" from the Google API Console?\n(https://www.google.ca/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&ved=0CC4QFjAA&url=http%3A%2F%2Fcode.google.com%2Fapis%2Fconsole&ei=RgdEUvu-GM754AOeh4GgAQ&usg=AFQjCNFikY2jzXn9SOuZu0UcyS-59LlsTw&sig2=hpYvu7CrTb8royXO9f3nyQ&bvm=bv.53217764,d.dmg)'
+        print ' - Did you use exactly the right ID and Secret for "Client for Installed Applications" from the Google API Console?'
         exit(-1)
     
     expiry = (datetime.datetime.now() + datetime.timedelta(0,response['expires_in'])).strftime('%Y-%m-%d %H:%M')
@@ -506,18 +476,15 @@ if __name__ == '__main__':
         print '               Client secret : {}\n'.format(credentials.google_project_client_secret)
 
     personal = False
-    # personal = raw_input("\n\nDo you want to:\n\n (1) authorize just yourself in a browser or, \n (2) email an authorization request code to a user and ask them to tell Google to let you in?\n\n        (1 or 2)  : ") in ("1")
+    personal = raw_input("\n\nDo you want to:\n\n (1) authorize just yourself in a browser or, \n (2) email an authorization request code to a user and ask them to tell Google to let you in?\n\n        (1 or 2)  : ") in ("1")
     
     if personal:
         manual = raw_input("\n\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
         credentials = first_person_auth(credentials, manual)
     else:
     
-        credentials.end_user_email = "martinhbramwell@gmail.com"
-        credentials.client_email = "mhb.warehouseman@gmail.com"
-
-        # credentials.client_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
-        # credentials.end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
+        credentials.client_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
+        credentials.end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
 
         credentials = third_person_auth(credentials)
         

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -116,9 +116,9 @@ if __name__ == '__main__':
         print '   - APIs & auth '
         print '      - Credentials '
         print '          - Client ID for native application'
-        print '             - [Download JSON]\n\n'
-        client_id = raw_input('Paste your Google "Client ID" : ')
-        client_secret = raw_input('Paste your Google "Client Secret" : ')
+        print '             - [Download JSON]'
+        client_id = raw_input('\nPaste your Google "Client ID" : ')
+        client_secret = raw_input('\nPaste your Google "Client Secret" : ')
         
     else:
         theFile = json_files[0]

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -66,20 +66,27 @@ def main(id, secret, manual=True):
     print ""
     print " .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  . "
 
+
+    creds_oa = open('creds_oa.py', 'w')
+    creds_oa.write("\nrefresh_token = '{}'".format(credentials.refresh_token))
+    creds_oa.write("\nclient_secret = '{}'".format(secret))
+    creds_oa.write("\nclient_id = '{}'".format(id))
+    creds_oa.write("\n#")
+    creds_oa.write("\nkey_ring = {}")
+    creds_oa.write("\nkey_ring['grant_type'] = 'refresh_token'")
+    creds_oa.write("\nkey_ring['refresh_token'] = refresh_token")
+    creds_oa.write("\nkey_ring['client_secret'] = client_secret")
+    creds_oa.write("\nkey_ring['client_id'] = client_id")
+    creds_oa.write("\n#")
+    creds_oa.write("\naccess_token = '{}'".format(credentials.access_token))
+    creds_oa.write("\n#\n")
+    creds_oa.close()
+
     qiktest = open('qiktest.py', 'w')
-    qiktest.write("# - - - - - - - - - - - - - - - - - - - - - - - - - - -")
+    qiktest.write("#!/usr/bin/env python")
     qiktest.write("\n# -*- coding: utf-8 -*-")
     qiktest.write("\nimport gspread")
-    qiktest.write("\n#")
-    qiktest.write("\nrefresh_token = '{}'".format(credentials.refresh_token))
-    qiktest.write("\nclient_secret = '{}'".format(secret))
-    qiktest.write("\nclient_id = '{}'".format(id))
-    qiktest.write("\n#")
-    qiktest.write("\nkey_ring = {}")
-    qiktest.write("\nkey_ring['grant_type'] = 'refresh_token'")
-    qiktest.write("\nkey_ring['refresh_token'] = refresh_token")
-    qiktest.write("\nkey_ring['client_secret'] = client_secret")
-    qiktest.write("\nkey_ring['client_id'] = client_id")
+    qiktest.write("\nfrom creds_oa import access_token, key_ring")
     qiktest.write("\n#")
     qiktest.write("\naccess_token = '{}'".format(credentials.access_token))
     qiktest.write("\ngc = gspread.authorize(access_token, key_ring)")
@@ -90,14 +97,14 @@ def main(id, secret, manual=True):
     qiktest.write("\nfor sheet in wkbk.worksheets():")
     qiktest.write("\n    print ' - Sheet #{}: Id = {}  Title = {}'.format(cnt, sheet.id, sheet.title)")
     qiktest.write("\n    cnt += 1")
-    qiktest.write("\n#")
-    qiktest.write("\n# - - - - - - - - - - - - - - - - - - - - - - - - - - -")
+    qiktest.write("\n#\n")
     qiktest.close()
+    os.chmod('qiktest.py', 0o770)
     #
     print "\n\n   A simple example file called qiktest.py was written to disk."
     print "   It lists the names of the sheets in the target spreadsheet."
     print "   Test it with:"
-    print "      $  python qiktest.py\n\n\n"
+    print "      $  python qiktest.py  ## or possibly just  ./qiktest.py\n\n\n"
 
 if __name__ == '__main__':
 

--- a/tests/get_google_oauth2_creds.py
+++ b/tests/get_google_oauth2_creds.py
@@ -20,7 +20,31 @@
     https://developers.google.com/api-client-library/python/guide/aaa_oauth
 
 '''
-import os, sys, argparse, json
+import urllib
+
+try :
+
+    from oauth2 import GeneratePermissionUrl
+    from oauth2 import AuthorizeTokens
+    from oauth2 import GenerateOAuth2String
+    from oauth2 import RefreshToken
+    
+except ImportError :
+
+    # Get Google oauth2 helper file
+    webFile = urllib.urlopen('http://google-mail-oauth2-tools.googlecode.com/svn/trunk/python/oauth2.py')
+    localFile = open('oauth2.py', 'w')
+    localFile.write(webFile.read())
+    webFile.close()
+    localFile.close()
+    
+    from oauth2 import GeneratePermissionUrl
+    from oauth2 import AuthorizeTokens
+    from oauth2 import GenerateOAuth2String
+    from oauth2 import RefreshToken
+
+
+import os, sys, argparse, json, datetime, smtplib, base64, urllib2, time
 from pprint import pprint
 
 try:
@@ -32,13 +56,160 @@ except ImportError:
     print "ImportError: Please execute the following command (with root privileges):\npip install oauth2client"
     exit(-1)
 
+SCOPE = 'https://spreadsheets.google.com/feeds/'
+
 class NameSpace(object):
   def __init__(self, adict):
     self.__dict__.update(adict)
+    
 
-def main(id, secret, manual=True):
 
-    flow = OAuth2WebServerFlow(client_id=id,
+def third_person_auth(google_project_client_id, google_project_client_secret, client_email, end_user_email):
+    #smtp_credentials = prep_smtp(client_email, google_project_client_id, google_project_client_secret, True)
+    smtp_credentials = {'access_token': u'ya29.1.AADtN_UrB-lg5DHI6AcHM0A2YX--fEyfOi_xz4GiC-3qnY5i9UF9ps0k76nkbSi3xhHm1w', 'refresh_token': u'1/eUFgFZSSr3EvVpH2K46u33zMLHy2rauIhMeUbJCk-0k', 'expiry': '2014-01-22 14:15'}
+    print 'Got SMTP creds;\n\n{}'.format(smtp_credentials)
+    
+    data = {}
+    data['client_id'] = google_project_client_id # 	the client_id obtained from the APIs Console 	Indicates the client that is making the request. The value passed in this parameter must exactly match the value shown in the APIs Console.
+    data['scope'] = SCOPE  # Indicates the Google API access your application is requesting. The values passed in this parameter inform the consent page shown to the user. There is an inverse relationship between the number of permissions requested and the likelihood of obtaining user consent.
+    
+    url = 'https://accounts.google.com/o/oauth2/device/code'
+    parms = urllib.urlencode(data)
+
+    request = urllib2.Request (url, parms)
+
+    theJSON = json.loads(urllib2.urlopen(request).read())
+#    print 'Response as json : {}.'.format(theJSON)
+#    logging.debug('Response as json : {}.'.format(theJSON))
+
+    verification_url = theJSON['verification_url']
+    user_code = theJSON['user_code']
+    expiry = int(theJSON['expires_in'])
+    device_code = theJSON['device_code']
+    
+    subject = '%s wants permission to access your Google Spreadheets with "gspread".' % client_email
+    text = 'To give {} access to your spreadsheets, please copy this code [ {} ] to your clipboard, turn to {} and enter it in the field provided. You have {} minutes to do so.'.format(client_email, user_code, verification_url, expiry / 60)
+    
+    req = {}
+    req['sat'] = smtp_credentials['access_token']
+    req['srt'] = smtp_credentials['refresh_token']
+    req['user'] = end_user_email
+    req['text'] = text
+    req['expiry'] = expiry
+    req['subject'] = subject
+    req['client_id'] = google_project_client_id
+    req['user_code'] = user_code
+    req['device_code'] = device_code
+    req['client_email'] = client_email
+    req['client_secret'] = google_project_client_secret
+    req['verification_url'] = verification_url
+
+    print ' ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..    '
+    pretty (req)
+    print ' ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..     ..    '
+
+    sending = True
+    while sending :
+        try :
+        
+            request_approval(req)
+            sending = False
+            
+        except smtplib.SMTPSenderRefused as sr :
+
+            if sr[0] == 530 :
+                client_secret = req['client_secret']
+                smtp_refresh_token = req['srt']
+                if 'Authentication Required' in sr[1] :
+#                    print "  *    *   Do we get an 'invalid grant' error now ?   *    *    * "
+                    pass
+                    
+#                print 'Refresh required: %s ' % smtp_refresh_token
+#                print 'Client ID: %s, Secret: %s ' % (theCurrentOAuthClient, client_secret)
+
+                rslt = RefreshToken(
+                      req['client_id']
+                    , client_secret
+                    , smtp_refresh_token
+                )
+                if 'error' in rslt :
+#                    close_store()
+                    raise Exception("Cannot refresh invalid SMTP token. '%s' " % rslt['error'])
+                    
+                req['sat'] = rslt['access_token']
+                print 'New SMTP token : %s' % req['sat']
+    
+    return NameSpace(getAsForDevices(req))
+
+def getAsForDevices(rq) :
+    m = 'ForDevices'
+
+    client = rq['client_id']
+
+    # print 'Getting authorization for device for "%s"' % client
+
+    subject = '%s wants permission to access your Google Spreadheets with "gspread".' % rq['client_email']
+    
+    print "\n\n* * * * *  You have to verify that you DO allow this software to open your Google document space."
+    print     '* * * * *  Please check your email at %s.' % rq['user']
+    print     '* * * * *  The message "%s" contains further instructions for you.' % subject
+
+    data = {}
+
+    data['client_id'] = client
+    data['client_secret'] = rq['client_secret']
+    data['code'] = rq['device_code']
+    data['grant_type'] = 'http://oauth.net/grant_type/device/1.0'
+    
+    url = 'https://accounts.google.com/o/oauth2/token'
+    
+    parms = urllib.urlencode(data)
+
+    request = urllib2.Request (url, parms)
+
+    delay = 30
+    triesLimit = rq['expiry'] / delay
+    tries = triesLimit
+    while tries > 0 :
+    
+        theJSON = json.loads(urllib2.urlopen(request).read())
+        print 'Response as json : {}.'.format(theJSON)
+
+        if 'access_token' in theJSON :
+            print ' * * * Authorized ! * * * '
+            '''
+            store[theCurrentEndUser][theCurrentOAuthClient].access_token = theJSON['access_token']
+            store[theCurrentEndUser][theCurrentOAuthClient].refresh_token = theJSON['refresh_token']
+            store[theCurrentEndUser][theCurrentOAuthClient].auth_method = m
+
+            reopen_store()
+
+            logging.debug(
+                    '==>\nAccess token : {}\nRefresh token : {}'.format(
+                        store[theCurrentEndUser][theCurrentOAuthClient].access_token
+                      , store[theCurrentEndUser][theCurrentOAuthClient].refresh_token
+                    )
+            )
+            '''
+            
+            return theJSON
+            
+        elif 'error' in theJSON :
+            if tries < triesLimit :
+                time.sleep(delay)
+                print 'Trying again to get tokens.  {} tries remain.'.format(tries)
+        else :
+            print ' * * *  Uh oh ! * * * %s ' % theJSON
+            
+        tries -= 1
+        
+    print "Too late.  You'll have to repeat it all."
+    exit(-1)    
+    
+
+def first_person_auth(idClient, secret, manual=True):
+
+    flow = OAuth2WebServerFlow(client_id=idClient,
                                client_secret=secret,
                                scope='https://spreadsheets.google.com/feeds https://docs.google.com/feeds',
                                redirect_uri='http://example.com/auth_return')
@@ -47,7 +218,9 @@ def main(id, secret, manual=True):
 
     flags = NameSpace({'noauth_local_webserver': manual, 'auth_host_port' : [8080, 8090], 'auth_host_name' : 'localhost', 'logging_level' : POSITIONAL_WARNING})
 
-    credentials = run_flow(flow, storage, flags)
+    return run_flow(flow, storage, flags)
+    
+def prepare_result(idClient, secret, credentials):
 
     print "\n =    =    =    =    =    =    =    =    =    =    =    =    =    =   "
     print "\n\n Data for use in gspread 'nose' tests, in file test.config : "
@@ -58,7 +231,7 @@ def main(id, secret, manual=True):
     print "; These three values are obligatory for OAuth access, optional for UID/pwd access"
     print '; The "wizard" get_google_oauth2_creds.py will you guide through the necessary steps and provide the values to paste here.'
     print "client_secret: {}".format(secret)
-    print "client_id: {}".format(id)
+    print "client_id: {}".format(idClient)
     print "refresh_token: {}".format(credentials.refresh_token)
     print ""
     print "; This value is optional but will make the tests start sooner if the token is less than 60 minutes old."
@@ -70,7 +243,7 @@ def main(id, secret, manual=True):
     creds_oa = open('creds_oa.py', 'w')
     creds_oa.write("\nrefresh_token = '{}'".format(credentials.refresh_token))
     creds_oa.write("\nclient_secret = '{}'".format(secret))
-    creds_oa.write("\nclient_id = '{}'".format(id))
+    creds_oa.write("\nclient_id = '{}'".format(idClient))
     creds_oa.write("\n#")
     creds_oa.write("\nkey_ring = {}")
     creds_oa.write("\nkey_ring['grant_type'] = 'refresh_token'")
@@ -89,6 +262,9 @@ def main(id, secret, manual=True):
 
     creds_oa.close()
 
+    print 'Identify the Google spreadsheet you want to use; use the full URL ("http://" etc, etc) '
+    spreadsheet_url  = raw_input('Paste the full URL here : ')
+    #
     qiktest = open('qiktest.py', 'w')
     qiktest.write("#!/usr/bin/env python")
     qiktest.write("\n# -*- coding: utf-8 -*-")
@@ -113,6 +289,159 @@ def main(id, secret, manual=True):
     print "   Test it with:"
     print "      $  python qiktest.py  ## or possibly just  ./qiktest.py\n\n\n"
 
+
+def prep_smtp(google_client_email, google_client_id, google_client_secret, test_mail = False) :
+
+    expiry = ''    
+    scope = 'https://mail.google.com/'
+
+    print "\n    Acting as : {}".format(google_client_id)
+    print "\n    To be able to request authorization from your users by email, you need to authorize this program to use Google's email resender via {}.".format(google_client_email)
+    print "    Visit this url and follow the directions:\n"
+    print '  %s' % GeneratePermissionUrl(
+                                              google_client_id
+                                            , scope
+                                        )
+    authorization_code = raw_input('\n\n    * * * Enter verification code: ')
+
+    response = AuthorizeTokens  (
+                                      google_client_id
+                                    , google_client_secret
+                                    , authorization_code
+                                )
+    access_token = ''
+    refresh_token = ''
+        
+    try :
+        access_token = response['access_token']
+        refresh_token = response['refresh_token']
+    except :
+        print '\n\nServer reported   %s' % response
+        print ' - Did you get the *latest* verification code?'
+        print ' - Did you get all of it?'
+        print ' - Did you use exactly the right ID and Secret for "Client for Installed Applications" from the Google API Console?\n(https://www.google.ca/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&ved=0CC4QFjAA&url=http%3A%2F%2Fcode.google.com%2Fapis%2Fconsole&ei=RgdEUvu-GM754AOeh4GgAQ&usg=AFQjCNFikY2jzXn9SOuZu0UcyS-59LlsTw&sig2=hpYvu7CrTb8royXO9f3nyQ&bvm=bv.53217764,d.dmg)'
+        exit(-1)
+    
+    expiry = (datetime.datetime.now() + datetime.timedelta(0,response['expires_in'])).strftime('%Y-%m-%d %H:%M')
+    print '\nSuccess :'
+    print ' - Access Token: = %s' % access_token
+    print ' - Refresh Token: %s'% refresh_token
+    print ' - Access Token expires at : %s' % expiry
+        
+    smtp_conn = smtplib.SMTP('smtp.gmail.com', 587)
+    smtp_conn.set_debuglevel(False)
+    smtp_conn.ehlo('test')
+    smtp_conn.starttls()
+            
+    # Temporary token...
+    auth_string = GenerateOAuth2String  (
+                                              google_client_email
+                                            , access_token
+                                            , base64_encode = False
+                                        )
+    print ">>>>"
+    print auth_string
+    print ">>>>"
+    
+    # Preparing test email envelope . . 
+    title = 'Trash this email'
+    body = 'Congratulations. You have fully enabled mail transfer through Google SMTP.'
+    envelope = 'From: %s\nTo: %s\nSubject: %s\n\n%s' % (
+                  google_client_email
+                , google_client_email
+                , title
+                , body)
+ 
+    if test_mail :
+        print ' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+        print envelope
+        print ' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+            
+        try :
+        
+            smtp_conn.docmd('AUTH', 'XOAUTH2 ' + base64.b64encode(auth_string))
+            print 'Sending . . . '
+            smtp_conn.sendmail(google_client_email, google_client_email, envelope)
+            print '. . . sent!\n'
+            
+        except smtplib.SMTPSenderRefused as sr :
+            if sr[0] == 530 :
+                print 'Refresh required: Using %s' % refresh_token
+                access_token = RefreshToken(google_client_id, google_project_client_secret, refresh_token)
+                print 'New token : %s' % access_token
+                smtp_conn.docmd('AUTH', 'XOAUTH2 ' + base64.b64encode(auth_string))
+                
+                try :
+                        smtp_conn.sendmail(google_client_email, google_client_email, envelope)
+                except smtplib.SMTPSenderRefused as sr :
+                    print sr
+                    if sr[0] == 535 :
+                        print 'The access token is correct. Maybe the user id is wrong?'
+                        print '¿¿ Are you sure that <[{0}]> authorized <[{0}]> ??'.format(google_client_email)
+                        exit(-1)
+
+
+    
+    else :
+        print 'No test mail sent.'
+    
+    '''
+    print 'Appending latest tokens to the bottom of the file "test_parms.py". . . '
+    update_parms_file(access_token, refresh_token, expiry)
+    print ' . . done.\n'
+    '''
+    
+    return {'access_token':access_token, 'refresh_token':refresh_token, 'expiry': expiry}
+    
+def request_approval(args) :
+
+    client_id = args['client_id']
+    client_email = args['client_email']
+    client_secret = args['client_secret']
+    
+#    if store[theCurrentOAuthClient].smtp_access_token is None :
+#        args = prep_smtp(args, test_mail = True)
+#        store[theCurrentOAuthClient].smtp_access_token = args['sat']
+#        store[theCurrentOAuthClient].smtp_refresh_token = args['srt']
+        
+        
+
+    # print "Temporary token using %s and %s ."   %  (client_email, store[theCurrentOAuthClient].smtp_access_token)
+    auth_string = GenerateOAuth2String(client_email, args['sat'])
+            
+    message = 'From: %s\nTo: %s\nSubject: %s\n\n%s' % (client_email, args['user'], args['subject'], args['text'])
+#    print message
+
+    smtp_conn = smtplib.SMTP('smtp.gmail.com', 587)
+    smtp_conn.set_debuglevel(False)
+    smtp_conn.ehlo('test')
+    smtp_conn.starttls()
+    
+    smtp_conn.docmd('AUTH', 'XOAUTH2 ' + auth_string)
+    print 'Sending . . . '
+    smtp_conn.sendmail(client_email, args['user'], message)
+    print ' . . sent!'
+    
+    smtp_conn.close()
+
+
+def pretty(dictionary, indent = 0):
+
+    dctnry = dictionary
+
+    if 'NameSpace' in '{}'.format(type(dctnry)) :
+            dctnry = vars(dictionary)
+
+    for key, value in dctnry.iteritems():
+        txt = '.  ' * indent + str(key) + ' : '
+        if isinstance(value, dict) or 'NameSpace' in '{}'.format(type(value)) :
+            print txt
+            pretty(value, indent + 1)
+            if indent == 0 : print '\n'
+        else:
+            print txt + str(value)
+
+
 if __name__ == '__main__':
 
     json_files = []
@@ -124,8 +453,8 @@ if __name__ == '__main__':
             json_files.append(f)
             
     theFile = None
-    client_id = None
-    client_secret = None
+    google_project_client_id = None
+    google_project_client_secret = None
     if cnt < 1:
         print '\n\nCould not find exactly one (1) expected json file (named like "client_secret_*.json" for example).'
         print 'You get such a file from https://cloud.google.com/console in the sub-section :'
@@ -133,8 +462,8 @@ if __name__ == '__main__':
         print '      - Credentials '
         print '          - Client ID for native application'
         print '             - [Download JSON]'
-        client_id = raw_input('\nPaste your Google "Client ID" : ')
-        client_secret = raw_input('\nPaste your Google "Client Secret" : ')
+        google_project_client_id = raw_input('\nPaste your Google "Client ID" : ')
+        google_project_client_secret = raw_input('\nPaste your Google "Client Secret" : ')
         
     else:
         theFile = json_files[0]
@@ -148,16 +477,28 @@ if __name__ == '__main__':
         
         json_data = open(theFile)
         oauth_creds = json.load(json_data)['installed']
-        client_id = oauth_creds['client_id']
-        client_secret = oauth_creds['client_secret']
+        google_project_client_id = oauth_creds['client_id']
+        google_project_client_secret = oauth_creds['client_secret']
         json_data.close()
         print '\n The file "{}" contains :\n'.format(theFile)
-        print '               Client id : {}'.format(client_id)
-        print '               Client secret : {}\n'.format(client_secret)
+        print '               Client id : {}'.format(google_project_client_id)
+        print '               Client secret : {}\n'.format(google_project_client_secret)
+
+    personal = False
+    personal = raw_input("\n\nDo you want to:\n\n (1) authorize just yourself in a browser or, \n (2) email an authorization request code to a user and ask them to tell Google to let you in?\n\n        (1 or 2)  : ") in ("1")
     
-    print 'Identify the Google spreadsheet you want to use; use the full URL ("http://" etc, etc) '
-    spreadsheet_url  = raw_input('Paste the full URL here : ')
-    #
-    manual = raw_input("\n\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
+    if personal:
+        manual = raw_input("\n\nShall we try to open a page in your browser?  (Y/y)  : ") not in "Yy"
+        credentials = first_person_auth(google_project_client_id, google_project_client_secret, manual)
+    else:
+######        your_email = raw_input("\n\nEnter a GMail address to be used as an SMTP server : ")
+######        end_user_email = raw_input("\n\nEnter the GMail address of the person who requested spreadsheet work : ")
+
+        end_user_email = "mhb.warehouseman@gmail.com"
+        your_email = "alicia.factorepo@gmail.com"
+        credentials = third_person_auth(google_project_client_id, google_project_client_secret, your_email, end_user_email)
+        
+    print '\n Credentials are :\n{}'.format(credentials)
+    prepare_result(google_project_client_id, google_project_client_secret, credentials)
     
-    main(client_id, client_secret, manual)
+    

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,10 +21,27 @@ class GspreadTest(unittest.TestCase):
                 os.path.dirname(__file__), creds_filename)
             config = ConfigParser.ConfigParser()
             config.readfp(open(config_filename))
-            email = config.get('Google Account', 'email')
-            password = config.get('Google Account', 'password')
+            
             self.config = config
-            self.gc = gspread.login(email, password)
+            
+            auth_type = config.get('Google Account', 'auth_type')
+            if auth_type == 'OAuth':
+                #
+                key_ring = {}
+                key_ring['grant_type'] = 'refresh_token'
+                key_ring['refresh_token'] = config.get('Google Account', 'refresh_token')
+                key_ring['client_secret'] = config.get('Google Account', 'client_secret')
+                key_ring['client_id'] = config.get('Google Account', 'client_id')
+                #
+                access_token = config.get('Google Account', 'access_token')
+                #
+                self.gc = gspread.authorize(access_token, key_ring)
+
+            else:
+                #
+                email = config.get('Google Account', 'email')
+                password = config.get('Google Account', 'password')
+                self.gc = gspread.login(email, password)
 
             self.assertTrue(isinstance(self.gc, gspread.Client))
         except IOError:

--- a/tests/test.py
+++ b/tests/test.py
@@ -108,7 +108,15 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(self.sheet.get_int_addr('ABC3'), (3, 731))
 
     def test_get_addr_int(self):
-        self.assertEqual(self.sheet.get_addr_int(3, 731), ('ABC3'))
+        self.assertEqual(self.sheet.get_addr_int(3, 731), 'ABC3')
+        self.assertEqual(self.sheet.get_addr_int(1, 104),'CZ1')
+
+    def test_addr_converters(self):
+        for row in range(1, 257):
+            for col in range(1, 512):
+                addr = self.sheet.get_addr_int(row, col)
+                (r, c) = self.sheet.get_int_addr(addr)
+                self.assertEqual((row, col), (r, c))
 
     def test_acell(self):
         cell = self.sheet.acell('A1')

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -2,6 +2,14 @@
 email: example@gmail.com
 password: password
 
+auth_type: UIDPwd
+# auth_type: OAuth
+
+client_secret: 
+client_id: 
+access_token: 
+refresh_token: 
+
 [Spreadsheet]
 title:
 key:

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -8,7 +8,8 @@
 email: example@gmail.com
 password: password
 
-; Uncomment in order to switch to OAuth access authentication. Optional.
+; Toggle the commenting below, in order to switch to OAuth access authentication. Optional.
+auth_type: 
 ; auth_type: OAuth
 
 ; These three values are obligatory for OAuth access, optional for UID/pwd access

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -1,23 +1,40 @@
+; These are the settings for "nose" testing of gspread
+; From the root directory of gspread run the command :
+;    nosetests
+
 [Google Account]
+
+; These two values are obligatory for UID/pwd access, optional for OAuth access
 email: example@gmail.com
 password: password
 
-auth_type: UIDPwd
-# auth_type: OAuth
+; Uncomment in order to switch to OAuth access authentication. Optional.
+; auth_type: OAuth
 
+; These three values are obligatory for OAuth access, optional for UID/pwd access
+; The "wizard" get_google_oauth2_creds.py will you guide through the necessary steps and provide the values to paste here.
 client_secret: 
 client_id: 
-access_token: 
 refresh_token: 
 
+; This value is optional but will make the tests start sooner if the token is less than 60 minutes old.
+access_token: 
+
 [Spreadsheet]
+
+; Used by  the test "open" 
 title:
-key:
+; Used by  the test "test_open_by_url" 
 url:
+; Used by  the test "test_open_by_key"
+key:
+; Used by  the test "test_worksheet"
 sheet1_title:
 
 [Worksheet]
+; Used by  the test "test_properties"
 id:
 title:
 row_count:
 col_count:
+

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -30,12 +30,12 @@ url:
 ; Used by  the test "test_open_by_key"
 key:
 ; Used by  the test "test_worksheet"
-sheet1_title:
+sheet1_title: Sheet1
 
 [Worksheet]
-; Used by  the test "test_properties"
-id:
-title:
-row_count:
-col_count:
+; Used by  the test "test_properties".  The values below are Google's defaults on a new spreadsheet.
+id: od6
+title: Sheet1
+row_count: 100
+col_count: 20
 


### PR DESCRIPTION
Hi again Anton,

In my second attempt here, I have shaved the code down to the bare minimum necessary to handle usage, *and refreshing*, of OAuth authorization credentials.

Apart from the altered code you see below I have also created [a new *gist*](https://gist.github.com/martinhbramwell/7553524) demo script and [a new wiki page](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.) both elaborating on the ones you did.

In the gist, you will see that I replaced the deprecated _run()_ procedure call with the more recent one _run-flow()_. I also prompt the user to enter required data, rather than have them edit the file.  I generate a complete set of Python variables to be used in any program that needs to use gspread with OAuth.

I copied and enhanced your wiki page.  My changes add two new sections.  The [first addition](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.#wiki-authenticationNew) explains how to get authentication credentials from Google's recently published new API Console.  The [second addition](https://github.com/FleetingClouds/gspread/wiki/How-to-get,-use-and-refresh-OAuth-access-tokens-for-gspread.#wiki-authorizationRefresh) explains how to set up and test my alternative "authorize()" method in a *virtualenv* environment, so as not to risk reconfiguring the user's system inappropriately.

Before committing, I pulled your latest changes so that you can merge this request automatically.

Sincere regards,
MHJB

