### PR TITLE
Use http_session parameter in Client ctor

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -49,9 +49,7 @@ class Client(object):
     """
     def __init__(self, auth, http_session=None):
         self.auth = auth
-
-        if not http_session:
-            self.session = HTTPSession()
+        self.session = http_session or HTTPSession()
 
     def _get_auth_token(self, content):
         for line in content.splitlines():


### PR DESCRIPTION
This fixes #102 by allowing the use of a pre-authenticated http Session with gspread. Until this fix is in main, users can achieve this by setting the Client.session directly member if it is found to be None.

References:

http://stackoverflow.com/questions/21420777/how-would-one-convert-wrap-a-httplib2-instance-as-a-session

http://stackoverflow.com/questions/21467305/how-to-authenticate-with-google-spreadsheets-api-using-python-client-discovery
