### PR TITLE
Add "If-Match" header to PUT and POST requests for new spreadsheets.

### DIFF
--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -48,6 +48,12 @@ class HTTPSession(object):
         if data is not None:
             data = data.encode()
 
+        if headers is None:
+            headers = {}
+        
+        if method in ['PUT', 'POST']:
+            headers['If-Match'] = '*'
+            
         # If we have data and Content-Type is not set, set it...
         if data and not headers.get('Content-Type', None):
             headers['Content-Type'] = 'application/x-www-form-urlencoded'


### PR DESCRIPTION
The "New" Google spreadsheets now work, once you add this header.
Before this, they could be read but not updated (though would not raise
an error). Now, read-write access is restored.

As recommended by @sadovnychyi in his comment to issue #123
https://github.com/burnash/gspread/issues/123#issuecomment-42134685
