### PR TITLE
Let range accept integers

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -311,13 +311,20 @@ class Worksheet(object):
                                                   self._cell_addr(row, col))
         return Cell(self, feed)
 
-    def range(self, alphanum):
+    def range(self, alphanumorrowcol):
         """Returns a list of :class:`Cell` objects from specified range.
 
-        :param alphanum: A string with range value in common format,
-                         e.g. 'A1:A5'.
+        :param alphanumorrowcol: A string with range value in common format,
+                                 e.g. 'A1:A5', or a sequence of integers
+                                 ``(startrow, startcol, endrow, endcol)``
 
         """
+        if isinstance(alphanumorrowcol, basestring):
+            alphanum = alphanumorrowcol
+        else:
+            startalphanum = self.get_addr_int(*alphanumorrowcol[:2])
+            endalphanum = self.get_addr_int(*alphanumorrowcol[-2:])
+            alphanum = ':'.join((startalphanum, endalphanum))
         feed = self.client.get_cells_feed(self, params={'range': alphanum,
                                                         'return-empty': 'true'})
         return [Cell(self, elem) for elem in feed.findall(_ns('entry'))]

--- a/tests/test.py
+++ b/tests/test.py
@@ -127,9 +127,14 @@ class WorksheetTest(GspreadTest):
         self.assertTrue(isinstance(cell, gspread.Cell))
 
     def test_range(self):
-        cell_range = self.sheet.range('A1:A5')
-        for c in cell_range:
-            self.assertTrue(isinstance(c, gspread.Cell))
+        cell_range1 = self.sheet.range('A1:A5')
+        cell_range2 = self.sheet.range((1, 1, 5, 1))
+        for c1, c2 in zip(cell_range1, cell_range2):
+            self.assertTrue(isinstance(c1, gspread.Cell))
+            self.assertTrue(isinstance(c2, gspread.Cell))
+            self.assertTrue(c1.col == c2.col)
+            self.assertTrue(c1.row == c2.row)
+            self.assertTrue(c1.value == c2.value)
 
     def test_update_acell(self):
         value = hashlib.md5(str(time.time())).hexdigest()


### PR DESCRIPTION
This fairly simple PR adds an interface convenience to `Worksheet.range`.  In master, range only accepts range strings like 'A1:C4'.  As a result, I regularly find myself doing things like `ws.range(ws.get_addr_int(1, 1) + ':' + ws.get_addr_int(4, 3)`.  This PR just makes it so that `range` can accept integer sequences _in addition_ to the current behavior.  So, e.g., I can just do `ws.range((1,1,4,3))` after this.

I could also change it to use `*args` instead, allowing either `ws.range('A1:C4')` or `ws.range(1,1,4,3)`, but I wasn't sure if there's a preference against `*args` in `gspread`'s API or not.
