### PR TITLE
Fix issue with del_worksheet

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -251,7 +251,11 @@ class Client(object):
     def del_worksheet(self, worksheet):
         url = construct_url(
             'worksheet', worksheet, 'private', 'full', worksheet_version=worksheet.version)
-        self.session.delete(url)
+        r = self.session.delete(url)
+        # Even though there is nothing interesting in the response body
+        # we have to read it or the next request from this session will get a
+        # httplib.ResponseNotReady error.
+        r.read()
 
     def get_cells_cell_id_feed(self, worksheet, cell_id,
                                visibility='private', projection='full'):

--- a/tests/test.py
+++ b/tests/test.py
@@ -324,6 +324,22 @@ class WorksheetTest(GspreadTest):
         self.sheet.resize(num_rows, num_cols)
 
 
+class WorksheetDeleteTest(GspreadTest):
+
+    def setUp(self):
+        super(WorksheetDeleteTest, self).setUp()
+        title = self.config.get('Spreadsheet', 'title')
+        self.spreadsheet = self.gc.open(title)
+        ws1_name = self.config.get('WorksheetDelete', 'ws1_name')
+        ws2_name = self.config.get('WorksheetDelete', 'ws2_name')
+        self.ws1 = self.spreadsheet.add_worksheet(ws1_name, 1, 1)
+        self.ws2 = self.spreadsheet.add_worksheet(ws2_name, 1, 1)
+
+    def test_delete_multiple_worksheets(self):
+        self.spreadsheet.del_worksheet(self.ws1)
+        self.spreadsheet.del_worksheet(self.ws2)
+
+
 class CellTest(GspreadTest):
     """Test for gspread.Cell."""
 

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -13,3 +13,8 @@ id:
 title:
 row_count:
 col_count:
+
+[WorksheetDelete]
+ws1_name:
+ws2_name:
+


### PR DESCRIPTION
Make sure the response from the DELETE request when deleting a worksheet gets read by the client else we get a httplib.ResponseNotReady error on the next request to that HTTP connection.  Also added a test and a couple of entries in the test config.  Fixes #84.

Note that I am getting a couple of errors when running the unit tests that are unrelated to this change.  Perhaps I've not configured my test environment correctly.
