### PR TITLE
Automatically refresh OAuth2 token when it has expired

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -81,7 +81,8 @@ class Client(object):
         service = 'wise'
 
         if hasattr(self.auth, 'access_token'):
-            if not self.auth.access_token:
+            if not self.auth.access_token or \
+                    (hasattr(self.auth, 'access_token_expired') and self.auth.access_token_expired):
                 import httplib2
                 
                 http = httplib2.Http()


### PR DESCRIPTION
If `OAuth2Credentials.authorize()` had been used, it would have replaced the `request` with `new_request` which checks for token expiry by comparing the HTTP status codes, and called `refresh` when needed to get a new `access_token`.

This fix checks for token expiry based on the expiry time, and calls `refresh` if necessary.
