### PR TITLE
Add title proeprty on Spreadsheet

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -53,9 +53,12 @@ class Spreadsheet(object):
 
     def __init__(self, client, feed_entry):
         self.client = client
-        id_parts = feed_entry.find(_ns('id')).text.split('/')
-        self.id = id_parts[-1]
         self._sheet_list = []
+        self._feed_entry = feed_entry
+
+    @property
+    def id(self):
+        return self._feed_entry.find(_ns('id')).text.split('/')[-1]
 
     def get_id_fields(self):
         return {'spreadsheet_id': self.id}
@@ -156,6 +159,9 @@ class Spreadsheet(object):
         """Shortcut property for getting the first worksheet."""
         return self.get_worksheet(0)
 
+    @property
+    def title(self):
+        return self._feed_entry.find(_ns('title')).text
 
 class Worksheet(object):
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -70,6 +70,12 @@ class SpreadsheetTest(GspreadTest):
         title = self.config.get('Spreadsheet', 'title')
         self.spreadsheet = self.gc.open(title)
 
+    def test_properties(self):
+        self.assertEqual(self.config.get('Spreadsheet', 'id'),
+                         self.spreadsheet.id)
+        self.assertEqual(self.config.get('Spreadsheet', 'title'),
+                         self.spreadsheet.title)
+
     def test_sheet1(self):
         sheet1 = self.spreadsheet.sheet1
         self.assertTrue(isinstance(sheet1, gspread.Worksheet))

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -3,6 +3,7 @@ email: example@gmail.com
 password: password
 
 [Spreadsheet]
+id:
 title:
 key:
 url:


### PR DESCRIPTION
The goal here is to simplify code that wants to find all spreadsheets whose titles match a particular regular expressions.  This creates a property of Spreadsheet, `title`, which evaluates to the title of the sheet.  I then use `openall()` and loop over the sheets comparing the title on each.
