### PR TITLE
Adding row selection for keys in method get_all_records.

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -348,9 +348,9 @@ class Worksheet(object):
 
         return [[rows[i][j] for j in rect_cols] for i in rect_rows]
 
-    def get_all_records(self, empty2zero=False):
+    def get_all_records(self, empty2zero=False, head=1):
         """Returns a list of dictionaries, all of them having:
-            - the contents of the spreadsheet's first row of cells as keys,
+            - the contents of the spreadsheet's with the head row as keys,
             And each of these dictionaries holding
             - the contents of subsequent rows of cells as values.
 
@@ -358,11 +358,15 @@ class Worksheet(object):
         Cell values are numericised (strings that can be read as ints
         or floats are converted).
 
-        :param empty2zero: determines whether empty cells are converted to zeros."""
+        :param empty2zero: determines whether empty cells are converted to zeros.
+        :param head: determines wich row to use as keys, starting from 1
+            following the numeration of the spreadsheet."""
+
+        idx = head - 1
 
         data = self.get_all_values()
-        keys = data[0]
-        values = [numericise_all(row, empty2zero) for row in data[1:]]
+        keys = data[idx]
+        values = [numericise_all(row, empty2zero) for row in data[idx + 1:]]
 
         return [dict(zip(keys, row)) for row in values]
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -309,6 +309,45 @@ class WorksheetTest(GspreadTest):
         d1 = dict(zip(rows[0], (0, 0, 0, 0)))
         self.assertEqual(read_records[1], d1)
 
+    def test_get_all_records_different_header(self):
+        # make a new, clean worksheet
+        # same as for test_all_values, find a way to refactor it
+        self.spreadsheet.add_worksheet('get_all_records', 10, 5)
+        sheet = self.spreadsheet.worksheet('get_all_records')
+
+        # put in new values, made from three lists
+        rows = [["", "", "", ""],
+                ["", "", "", ""],
+                ["A1", "B1", "", "D1"],
+                [1, "b2", 1.45, ""],
+                ["", "", "", ""],
+                ["A4", 0.4, "", 4]]
+        cell_list = sheet.range('A1:D1')
+        cell_list.extend(sheet.range('A2:D2'))
+        cell_list.extend(sheet.range('A3:D3'))
+        cell_list.extend(sheet.range('A4:D4'))
+        cell_list.extend(sheet.range('A5:D5'))
+        cell_list.extend(sheet.range('A6:D6'))
+        for cell, value in zip(cell_list, itertools.chain(*rows)):
+            cell.value = value
+        sheet.update_cells(cell_list)
+
+        # first, read empty strings to empty strings
+        read_records = sheet.get_all_records(head=3)
+        d0 = dict(zip(rows[2], rows[3]))
+        d1 = dict(zip(rows[2], rows[4]))
+        d2 = dict(zip(rows[2], rows[5]))
+        self.assertEqual(read_records[0], d0)
+        self.assertEqual(read_records[1], d1)
+        self.assertEqual(read_records[2], d2)
+
+        # then, read empty strings to zeros
+        read_records = sheet.get_all_records(empty2zero=True, head=3)
+        d1 = dict(zip(rows[2], (0, 0, 0, 0)))
+        self.assertEqual(read_records[1], d1)
+
+        self.gc.del_worksheet(sheet)
+
     def test_append_row(self):
         num_rows = self.sheet.row_count
         num_cols = self.sheet.col_count


### PR DESCRIPTION
Adding a parameter `head` to the method `models.Worksheet.get_all_records` to be able to select the row where the keys are.
i.e: if a document have the first 2 rows with information that we don't want or we can't use as keys we specify the `head=3` and the 3rd row will be used as keys for each dictionary.
