### PR TITLE
Added the `numeric_value` attribute to `Cell`

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -624,6 +624,8 @@ class Cell(object):
         self._row = int(cell_elem.get('row'))
         self._col = int(cell_elem.get('col'))
         self.input_value = cell_elem.get('inputValue')
+        numeric_value = cell_elem.get('numericValue')
+        self.numeric_value = float(numeric_value) if numeric_value else None
 
         #: Value of the cell.
         self.value = cell_elem.text or ''

--- a/tests/test.py
+++ b/tests/test.py
@@ -428,12 +428,23 @@ class CellTest(GspreadTest):
         super(CellTest, self).setUp()
         title = self.config.get('Spreadsheet', 'title')
         sheet = self.gc.open(title).sheet1
-        self.update_value = hashlib.md5(str(time.time())).hexdigest()
-        sheet.update_acell('A1', self.update_value)
-        self.cell = sheet.acell('A1')
+        self.sheet = sheet
 
     def test_properties(self):
-        cell = self.cell
-        self.assertEqual(cell.value, self.update_value)
+        update_value = hashlib.md5(str(time.time())).hexdigest()
+        self.sheet.update_acell('A1', update_value)
+        cell = self.sheet.acell('A1')
+        self.assertEqual(cell.value, update_value)
         self.assertEqual(cell.row, 1)
         self.assertEqual(cell.col, 1)
+
+    def test_numeric_value(self):
+        numeric_value = 1.0 / 1024
+        # Use a formula here to avoid issues with differing decimal marks:
+        self.sheet.update_acell('A1', '= 1 / 1024')
+        cell = self.sheet.acell('A1')
+        self.assertEqual(cell.numeric_value, numeric_value)
+        self.assertIsInstance(cell.numeric_value, float)
+        self.sheet.update_acell('A1', 'Non-numeric value')
+        cell = self.sheet.acell('A1')
+        self.assertIs(cell.numeric_value, None)


### PR DESCRIPTION
The `Cell` model has been extended to include a `numeric_value` attribute, which is set to the `numericValue` attribute of the cell's XML element, or `None` if the attribute does not exist on the element.

This is useful in cases where the cell's text value has been formatted with less precision than what is actually available.

It might also help to detect cells whose values have been formatted as date or date time.

Note that the test indirectly inserts a numerical value into a cell by using a formula, this is to avoid issues with spreadsheets that use a locale with a different decimal mark.
