### PR TITLE
Clarified what goes into the OAuth2Credentials object

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ wks = gc.open("Where is the money Lebowski?").sheet1
 
 ```
 
-Note: You probably need to have oauth2client and httplib2 installed to create OAuth2 Credential objects. See ["Using OAuth2 for Authorization"](http://burnash.github.com/gspread/oauth2.html) for more information.
+OAuth2Credentials must be an object with a valid `access_token` attribute, such as one created with the oauth2client library from Google. See ["Using OAuth2 for Authorization"](http://burnash.github.com/gspread/oauth2.html) for more information.
 
 ### Two Factor Authorization
 


### PR DESCRIPTION
The documentation for `oauth2client` is piss-poor, so I worked through [one of their examples](https://github.com/google/oauth2client/blob/master/samples/oauth2_for_devices.py) to make a valid credentials object. Because there are other libraries that speak OAuth 2.0 and feature better documentation than `oauth2client`, this change might make it easier for people to use `gspread`.