### PR TITLE
add SSL default context to enable SSL certificate verification

### DIFF
--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -14,7 +14,6 @@ try:
     from urllib import urlencode
 except ImportError:
     from http import client
-    import ssl
     from urllib.parse import urlparse
     from urllib.parse import urlencode
 
@@ -24,6 +23,7 @@ except NameError:
     basestring = unicode = str
 
 
+import ssl
 from .exceptions import HTTPError
 
 

--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -14,6 +14,7 @@ try:
     from urllib import urlencode
 except ImportError:
     from http import client
+    import ssl
     from urllib.parse import urlparse
     from urllib.parse import urlencode
 
@@ -53,7 +54,7 @@ class HTTPSession(object):
         if not self.connections.get(uri.scheme + uri.netloc):
             if uri.scheme == 'https':
                 self.connections[
-                    uri.scheme + uri.netloc] = client.HTTPSConnection(uri.netloc)
+                    uri.scheme + uri.netloc] = client.HTTPSConnection(uri.netloc, context=ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH))
             else:
                 self.connections[
                     uri.scheme + uri.netloc] = client.HTTPConnection(uri.netloc)


### PR DESCRIPTION
All newer versions of python enabled certificate verification for the system
libs (e.g. httplib). Now one either needs to disable it again by hand or enable
some sort of certificate database against certificates are verified.

ssl.create_default_context() uses the system's trusted certificates.

https://docs.python.org/2/library/ssl.html#ssl.create_default_context