### PR TITLE
Paddle insert_row if len(columns) > len(values)

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -550,6 +550,8 @@ class Worksheet(object):
         data_width = len(values)
         if self.col_count < data_width:
             self.resize(cols=data_width)
+        else:
+            values += [''] * (self.col_count - data_width)
 
         all_cells = self.get_all_values()
         rows_after_insert = all_cells[index - 1:self.row_count]

--- a/tests/test.py
+++ b/tests/test.py
@@ -377,6 +377,19 @@ class WorksheetTest(GspreadTest):
         read_values = self.sheet.row_values(1)
         self.assertEqual(values, read_values)
 
+        # test if len(values) < num_cols
+        num_rows = self.sheet.row_count
+        num_cols = self.sheet.col_count
+        if num_cols >= 1:
+            values = ['o_0'] * (num_cols - 1)
+            self.sheet.insert_row(values, 1)
+            self.assertEqual(self.sheet.row_count, num_rows + 1)
+            self.assertEqual(self.sheet.col_count, num_cols)
+            read_values = self.sheet.row_values(1)
+            self.assertEqual(values, read_values[:-1])
+            paddle_value = read_values[-1]
+            self.assertEqual(paddle_value, '')
+
         # undo the appending and resizing
         # self.sheet.resize(num_rows, num_cols)
 


### PR DESCRIPTION
If there are more columns than values, we need to paddle some values (I used empty string) to the values. Otherwise, it preserves the original cell in the end of the inserted row.
