### PR TITLE
``ssl.SSLContext`` can be passed as argument to authenticate and login

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -41,6 +41,7 @@ class Client(object):
                  oauth2client library. https://github.com/google/oauth2client
     :param http_session: (optional) A session object capable of making HTTP requests while persisting headers.
                                     Defaults to :class:`~gspread.httpsession.HTTPSession`.
+    :param ssl_context: ``sslSSLContext`` object, if non-default needed.
 
     >>> c = gspread.Client(auth=('user@example.com', 'qwertypassword'))
 
@@ -50,9 +51,9 @@ class Client(object):
 
 
     """
-    def __init__(self, auth, http_session=None):
+    def __init__(self, auth, http_session=None, ssl_context=None):
         self.auth = auth
-        self.session = http_session or HTTPSession()
+        self.session = http_session or HTTPSession(ssl_context=ssl_context)
 
     def _get_auth_token(self, content):
         for line in content.splitlines():
@@ -309,29 +310,35 @@ class Client(object):
         return ElementTree.fromstring(r.read())
 
 
-def login(email, password):
+def login(email, password, ssl_context=None):
     """Login to Google API using `email` and `password`.
 
     This is a shortcut function which instantiates :class:`Client`
     and performs login right away.
 
+    :param ssl_context: If you want to use a non-default ssl context
+    (``ssl.SSLContext`` class)
+
     :returns: :class:`Client` instance.
 
     """
-    client = Client(auth=(email, password))
+    client = Client(auth=(email, password), ssl_context=ssl_context)
     client.login()
     return client
 
-def authorize(credentials):
+def authorize(credentials, ssl_context=None):
     """Login to Google API using OAuth2 credentials.
 
     This is a shortcut function which instantiates :class:`Client`
     and performs login right away.
 
+    :param ssl_context: If you want to use a non-default ssl context
+    (``ssl.SSLContext`` class)
+
     :returns: :class:`Client` instance.
 
     """
-    client = Client(auth=credentials)
+    client = Client(auth=credentials, ssl_context=ssl_context)
     client.login()
     return client
 

--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -31,11 +31,14 @@ class HTTPSession(object):
     """Handles HTTP activity while keeping headers persisting across requests.
 
        :param headers: A dict with initial headers.
+       :param ssl_context: The ssl context to be passed to the HTTPS connection
+       client, if non-default
     """
 
-    def __init__(self, headers=None):
+    def __init__(self, headers=None, ssl_context=None):
         self.headers = headers or {}
         self.connections = {}
+        self.ssl_context = ssl_context
 
     def request(self, method, url, data=None, headers=None):
         if data and not isinstance(data, basestring):
@@ -53,7 +56,8 @@ class HTTPSession(object):
         if not self.connections.get(uri.scheme + uri.netloc):
             if uri.scheme == 'https':
                 self.connections[
-                    uri.scheme + uri.netloc] = client.HTTPSConnection(uri.netloc)
+                    uri.scheme + uri.netloc] = client.HTTPSConnection(
+                        uri.netloc, context=self.ssl_context)
             else:
                 self.connections[
                     uri.scheme + uri.netloc] = client.HTTPConnection(uri.netloc)


### PR DESCRIPTION
An `ssl.SSLContext` object as argment of `authenticate` or `login` is passed through to the `HTTPConnection` object.

After an OS X update, my computer was not ok verifying the remote SSL host, through the default SSL context.

```
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)
```

Passing the context directly seemed to me like the simplest and most direct way to make it possible to the developer to control the way the machine is validating the Google servers certificate.
