### PR TITLE
Fixed HTTPError usage

### DIFF
--- a/gspread/exceptions.py
+++ b/gspread/exceptions.py
@@ -43,3 +43,6 @@ class RequestError(GSpreadException):
 
 class HTTPError(RequestError):
     """DEPRECATED. Error while sending API request."""
+    def __init__(self, code, msg):
+        super(HTTPError, self).__init__(msg)
+        self.code = code

--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -72,7 +72,7 @@ class HTTPSession(object):
         response = self.connections[uri.scheme + uri.netloc].getresponse()
 
         if response.status > 399:
-            raise HTTPError("%s: %s" % (response.status, response.read()))
+            raise HTTPError(response.status, "%s: %s" % (response.status, response.read()))
         return response
 
     def get(self, url, **kwargs):


### PR DESCRIPTION
I know the usage is deprecated but this Exception is still used in httpsession.py so for now it should at least do what it was intended for