### PR TITLE
Iterworksheets

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -164,6 +164,10 @@ class Spreadsheet(object):
     def title(self):
         return self._feed_entry.find(_ns('title')).text
 
+    def __iter__(self):
+        for sheet in self.worksheets():
+            yield(sheet)
+
 
 class Worksheet(object):
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -113,6 +113,10 @@ class SpreadsheetTest(GspreadTest):
         sheet = self.spreadsheet.worksheet(sheet_title)
         self.assertTrue(isinstance(sheet, gspread.Worksheet))
 
+    def test_worksheet_iteration(self):
+        self.assertEqual(self.spreadsheet.worksheets(), 
+            [sheet for sheet in self.spreadsheet])
+
 
 class WorksheetTest(GspreadTest):
 


### PR DESCRIPTION
Thank you for making such an incredibly easy to use api I still think certain special methods could make life just a little easier. 

My addition allows for iteration through a spreadsheet's worksheets. I understand if you do not like this implementation and would rather have people use the worksheets() method for iteration instead. 

I see issue #271 has asked for supporting keys. I will happily add this as well.

Kind regards,
Marc