### PR TITLE
Adding hint to share document with service-account in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Features:
 
 1. [Obtain OAuth2 credentials from Google Developers Console](http://gspread.readthedocs.org/en/latest/oauth2.html)
 
-2. Start using gspread:
+2. Share your spreadsheet with the `client_email` found in the downloaded .json-file from the Developer Console. 
+
+3. Start using gspread:
 
 ```python
 import gspread


### PR DESCRIPTION
The Readme is missing an important hint: If you want to be able to edit a file with the .json-credentials, you need to share it with the service-account created.

Adding this hint to README - I am sure there are people out there who run into this problem, too.