### PR TITLE
Use lxml if available

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -11,7 +11,12 @@ Google Data API.
 import re
 import warnings
 
-from xml.etree import ElementTree
+try:
+    from lxml import etree
+    fromstring = etree.fromstring # Roughly 3x faster parsing for large worksheets
+except ImportError:
+    from xml.etree import ElementTree
+    fromstring = ElementTree.fromstring
 
 from . import __version__
 from . import urlencode
@@ -229,7 +234,7 @@ class Client(object):
                             visibility=visibility, projection=projection)
 
         r = self.session.get(url)
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def get_worksheets_feed(self, spreadsheet,
                             visibility='private', projection='full'):
@@ -237,7 +242,7 @@ class Client(object):
                             visibility=visibility, projection=projection)
 
         r = self.session.get(url)
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def get_cells_feed(self, worksheet,
                        visibility='private', projection='full', params=None):
@@ -250,11 +255,11 @@ class Client(object):
             url = '%s?%s' % (url, params)
 
         r = self.session.get(url)
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def get_feed(self, url):
         r = self.session.get(url)
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def del_worksheet(self, worksheet):
         url = construct_url(
@@ -267,7 +272,7 @@ class Client(object):
                             visibility=visibility, projection=projection)
 
         r = self.session.get(url)
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def put_feed(self, url, data):
         headers = {'Content-Type': 'application/atom+xml',
@@ -282,7 +287,7 @@ class Client(object):
             else:
                 raise
 
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def post_feed(self, url, data):
         headers = {'Content-Type': 'application/atom+xml'}
@@ -293,7 +298,7 @@ class Client(object):
         except HTTPError as ex:
             raise RequestError(ex.message)
 
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
     def post_cells(self, worksheet, data):
         headers = {'Content-Type': 'application/atom+xml',
@@ -302,7 +307,7 @@ class Client(object):
         url = construct_url('cells_batch', worksheet)
         r = self.session.post(url, data, headers=headers)
 
-        return ElementTree.fromstring(r.content)
+        return fromstring(r.content)
 
 
 def login(email, password):

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -12,8 +12,12 @@ import re
 from collections import defaultdict
 from itertools import chain
 
-from xml.etree import ElementTree
-from xml.etree.ElementTree import Element, SubElement
+try:
+    from lxml.etree import ElementTree
+    from lxml.etree.ElementTree import Element, SubElement
+except ImportError:
+    from xml.etree import ElementTree
+    from xml.etree.ElementTree import Element, SubElement
 
 from . import urlencode
 from .ns import _ns, _ns1, ATOM_NS, BATCH_NS, SPREADSHEET_NS

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -8,7 +8,10 @@ This module contains utility functions.
 
 """
 
-from xml.etree import ElementTree
+try:
+    from lxml.etree import ElementTree
+except ImportError:
+    from xml.etree import ElementTree
 
 
 def finditem(func, seq):


### PR DESCRIPTION
Refs #2 - Attempt to import `lxml` and revert to `xml` if it's not available. I've observed roughly a 3x speedup on parsing large spreadsheets (reduction of ~24 seconds for thousands of rows down to ~8 seconds) with `lxml`. A fairly simple change and all of the tests pass.
