### PR TITLE
Fix losing input_value data from following cells in insert_row

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -565,7 +565,7 @@ class Worksheet(object):
                 new_val = values[ind] if ind < len(values) else ''
             else:
                 # For all other rows, take the cell values from the row above
-                new_val = cells_after_insert[ind - self.col_count].value
+                new_val = cells_after_insert[ind - self.col_count].input_value
             cell.value = new_val
 
         self.update_cells(cells_after_insert)


### PR DESCRIPTION
Let's suppose that one have a spreadsheet which values after the inserted row are prefixed by single quote (to avoid formula's evaluation). Then someone inserts a row before it. And then the single quote become lost. To avoid it there is a one-line patch in the pull request.
