### PR TITLE
support public published spreadsheets

### DIFF
--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     from urllib.parse import urlencode
 
 
-from .client import Client, authorize
+from .client import Client, authorize, public
 from .models import Spreadsheet, Worksheet, Cell
 from .exceptions import (GSpreadException, AuthenticationError,
                          SpreadsheetNotFound, NoValidUrlKeyFound,

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -82,6 +82,9 @@ class Spreadsheet(object):
         self._sheet_list = []
         self._feed_entry = feed_entry
         self._id = feed_entry.find(_ns('id')).text.split('/')[-1]
+        if self._id == 'full':
+            # public sheet case, id is elsewhere
+            self._id = feed_entry.find(_ns('id')).text.split('/')[-3]
         self._title = feed_entry.find(_ns('title')).text
         self._updated = feed_entry.find(_ns('updated')).text
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -18,6 +18,7 @@ CELL_ADDR_RE = re.compile(r'([A-Za-z]+)([1-9]\d*)')
 
 URL_KEY_V1_RE = re.compile(r'key=([^&#]+)')
 URL_KEY_V2_RE = re.compile(r'/spreadsheets/d/([a-zA-Z0-9-_]+)')
+URL_KEY_V2_PUBLIC_RE = re.compile(r'spreadsheets/d/([a-zA-Z0-9-_]+)/pubhtml')
 
 
 def finditem(func, seq):
@@ -188,6 +189,11 @@ def wid_to_gid(wid):
     widval = wid[1:] if len(wid) > 3 else wid
     xorval = 474 if len(wid) > 3 else 31578
     return str(int(str(widval), 36) ^ xorval)
+
+
+def is_public_url(url):
+    m = URL_KEY_V2_PUBLIC_RE.search(url)
+    return bool(m)
 
 
 if __name__ == '__main__':

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -10,6 +10,12 @@ url: full url of this spreadsheet
 sheet1_title: title of the first worksheet
 new_spreadsheet_title: could be anything you like
 
+[PublicSpreadsheet]
+title:
+key:
+url:
+sheet1_title:
+
 [Worksheet]
 id: string following "#gid="
 title: title of this worksheet

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -11,10 +11,10 @@ sheet1_title: title of the first worksheet
 new_spreadsheet_title: could be anything you like
 
 [PublicSpreadsheet]
-title:
-key:
-url:
-sheet1_title:
+title: gspread public test 2 (public and published)
+key: 16i5mfs194m44guNIBUylgZrvNslQlkp7F9JNbQar7E4
+url: https://docs.google.com/spreadsheets/d/16i5mfs194m44guNIBUylgZrvNslQlkp7F9JNbQar7E4/edit?usp=sharing
+sheet1_title: Sheet1
 
 [Worksheet]
 id: string following "#gid="


### PR DESCRIPTION
This allows use of gspread without an authorization step when accessing public spreadsheets that have been "published to the web."

It adds a new gspread.public() alternative for creating a client. The client won't be able to access private spreadsheets.

An update to `tests.config` is needed to point to a published spreadsheet, some new unit tests added won't pass without that.

There's been some related discussion in #175.
