### PR TITLE
oauth2 documentation update

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -61,6 +61,19 @@ Depending on your system setup you may need to install PyOpenSSL:
 
 6. Now you can read this file, and use the data when constructing your credentials:
 
+::
+
+    import gspread
+    from oauth2client.service_account import ServiceAccountCredentials
+
+    scope = ['https://spreadsheets.google.com/feeds']
+
+    credentials = ServiceAccountCredentials.from_json_keyfile_name('gspread-april-2cd … ba4.json', scope)
+
+    gc = gspread.authorize(credentials)
+
+    wks = gc.open("Where is the money Lebowski?").sheet1
+
 If using oauth2client < 2.0.0
 
 ::
@@ -73,21 +86,6 @@ If using oauth2client < 2.0.0
     scope = ['https://spreadsheets.google.com/feeds']
 
     credentials = SignedJwtAssertionCredentials(json_key['client_email'], json_key['private_key'].encode(), scope)
-
-    gc = gspread.authorize(credentials)
-
-    wks = gc.open("Where is the money Lebowski?").sheet1
-
-If using oauth2client >= 2.0.0
-
-::
-
-    import gspread
-    from oauth2client.service_account import ServiceAccountCredentials
-
-    scope = ['https://spreadsheets.google.com/feeds']
-
-    credentials = ServiceAccountCredentials.from_json_keyfile_name('gspread-april-2cd … ba4.json', scope)
 
     gc = gspread.authorize(credentials)
 

--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -61,9 +61,27 @@ Depending on your system setup you may need to install PyOpenSSL:
 
 6. Now you can read this file, and use the data when constructing your credentials:
 
+If using oauth2client < 2.0.0
+
 ::
 
     import json
+    import gspread
+    from oauth2client.client import SignedJwtAssertionCredentials
+
+    json_key = json.load(open('gspread-april-2cd … ba4.json'))
+    scope = ['https://spreadsheets.google.com/feeds']
+
+    credentials = SignedJwtAssertionCredentials(json_key['client_email'], json_key['private_key'].encode(), scope)
+
+    gc = gspread.authorize(credentials)
+
+    wks = gc.open("Where is the money Lebowski?").sheet1
+
+If using oauth2client >= 2.0.0
+
+::
+
     import gspread
     from oauth2client.service_account import ServiceAccountCredentials
 

--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -69,7 +69,7 @@ Depending on your system setup you may need to install PyOpenSSL:
 
     scope = ['https://spreadsheets.google.com/feeds']
 
-    credentialss = ServiceAccountCredentials.from_json_keyfile_name('gspread-april-2cd … ba4.json', scope)
+    credentials = ServiceAccountCredentials.from_json_keyfile_name('gspread-april-2cd … ba4.json', scope)
 
     gc = gspread.authorize(credentials)
 

--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -65,12 +65,11 @@ Depending on your system setup you may need to install PyOpenSSL:
 
     import json
     import gspread
-    from oauth2client.client import SignedJwtAssertionCredentials
+    from oauth2client.service_account import ServiceAccountCredentials
 
-    json_key = json.load(open('gspread-april-2cd … ba4.json'))
     scope = ['https://spreadsheets.google.com/feeds']
 
-    credentials = SignedJwtAssertionCredentials(json_key['client_email'], json_key['private_key'].encode(), scope)
+    credentialss = ServiceAccountCredentials.from_json_keyfile_name('gspread-april-2cd … ba4.json', scope)
 
     gc = gspread.authorize(credentials)
 


### PR DESCRIPTION
Oauth2client version 2.0.0 removed SignedJwtAssertCredentials, which is referenced in your authorization readme. I've updated OAuth2.rst to now properly describe how to authorize with oauth2client 2.0.0 using a replacement method, ServiceAccountCredentials.