### PR TITLE
Update method to read credentials from file - closes #343, #356, #357

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -65,21 +65,17 @@ Depending on your system setup you may need to install PyOpenSSL:
 
     import json
     import gspread
-    from oauth2client.client import SignedJwtAssertionCredentials
-
-    json_key = json.load(open('gspread-april-2cd … ba4.json'))
+    from oauth2client.service_account import ServiceAccountCredentials
+    
     scope = ['https://spreadsheets.google.com/feeds']
 
-    credentials = SignedJwtAssertionCredentials(json_key['client_email'], json_key['private_key'].encode(), scope)
+    credentials = ServiceAccountCredentials.from_json_keyfile_name('gspread-april-2cd … ba4.json', scope)
 
     gc = gspread.authorize(credentials)
 
     wks = gc.open("Where is the money Lebowski?").sheet1
 
-**Note**: Python2 users do not need to encode ``json_key['private_key']`` due to ``str`` and ``bytes`` not being differentiated.
-
-
-7. Go to Google Sheets and share your spreadsheet with an email you have in your ``json_key['client_email']``. Otherwise you'll get a ``SpreadsheetNotFound`` exception when trying to open it.
+7. Go to Google Sheets and share your spreadsheet with an email you have in your file, gspread-april-2cd … ba4.json, under 'client_email' key. Otherwise you'll get a ``SpreadsheetNotFound`` exception when trying to open it.
 
 Troubleshooting
 ---------------

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,7 +11,8 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
-from oauth2client.client import SignedJwtAssertionCredentials
+from oauth2client.service_account import ServiceAccountCredentials
+
 
 import gspread
 
@@ -35,10 +36,7 @@ def read_config(filename):
 
 
 def read_credentials(filename):
-    creds_data = json.load(open(filename))
-    return SignedJwtAssertionCredentials(creds_data['client_email'],
-                                         creds_data['private_key'].encode(),
-                                         SCOPE)
+    return ServiceAccountCredentials.from_json_keyfile_name(filename, SCOPE)
 
 
 def gen_value(prefix=None):


### PR DESCRIPTION
SignedJwtAssertionCredentials is deprecated, replaced that with
new method with reads credentials directly from the file.

https://github.com/google/oauth2client/issues/401