### PR TITLE
Retry requests on Internal Server Errors

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -38,13 +38,16 @@ class Client(object):
                  oauth2client library. https://github.com/google/oauth2client
     :param http_session: (optional) A session object capable of making HTTP requests while persisting headers.
                                     Defaults to :class:`~gspread.httpsession.HTTPSession`.
+    :param max_retries: (optional) If using the default `http_session`, how many times to retry a
+                                   request when encountering internal server error responses.
+                                   Default is to retry four times.
 
     >>> c = gspread.Client(auth=OAuthCredentialObject)
 
     """
-    def __init__(self, auth, http_session=None):
+    def __init__(self, auth, http_session=None, max_retries=None):
         self.auth = auth
-        self.session = http_session or HTTPSession()
+        self.session = http_session or HTTPSession(max_retries=max_retries)
 
     def _ensure_xml_header(self, data):
         if data.startswith(b'<?xml'):
@@ -239,7 +242,7 @@ class Client(object):
         return ElementTree.fromstring(r.content)
 
 
-def authorize(credentials):
+def authorize(credentials, max_retries=None):
     """Login to Google API using OAuth2 credentials.
 
     This is a shortcut function which instantiates :class:`Client`
@@ -248,6 +251,6 @@ def authorize(credentials):
     :returns: :class:`Client` instance.
 
     """
-    client = Client(auth=credentials)
+    client = Client(auth=credentials, max_retries=max_retries)
     client.login()
     return client

--- a/tests/mock_tests.py
+++ b/tests/mock_tests.py
@@ -67,6 +67,10 @@ class MockClientTest(MockGspreadTest, test.ClientTest):
         feed = feed_obj.to_xml()
         cls.gc.get_spreadsheets_feed = mock.Mock(return_value=feed)
 
+    def test_retry_on_error(self):
+        # This test should not run when we're mocking.
+        pass
+
 
 class MockSpreadsheetTest(MockGspreadTest, test.SpreadsheetTest):
     """Test for gspread.Spreadsheet that mocks out the server response.

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,6 +11,7 @@ except ImportError:
     import configparser as ConfigParser
 
 from oauth2client.service_account import ServiceAccountCredentials
+from oauth2client.client import OAuth2Credentials
 
 import gspread
 
@@ -33,8 +34,12 @@ def read_config(filename):
     return config
 
 
-def read_credentials(filename):
+def read_service_account_credentials(filename):
     return ServiceAccountCredentials.from_json_keyfile_name(filename, SCOPE)
+
+
+def read_oauth2_credentials(filename):
+    return OAuth2Credentials.from_json(open(filename).read())
 
 
 def gen_value(prefix=None):
@@ -50,7 +55,11 @@ class GspreadTest(unittest.TestCase):
     def setUpClass(cls):
         try:
             cls.config = read_config(CONFIG_FILENAME)
-            credentials = read_credentials(CREDS_FILENAME)
+            if cls.config.has_option('Authorization', 'credentials_file'):
+                oauth2_credentials_file = cls.config.get('Authorization', 'credentials_file')
+                credentials = read_oauth2_credentials(oauth2_credentials_file)
+            else:
+                credentials = read_service_account_credentials(CREDS_FILENAME)
             cls.gc = gspread.authorize(credentials)
         except IOError as e:
             msg = "Can't find %s for reading test configuration. "

--- a/tests/tests.config.example
+++ b/tests/tests.config.example
@@ -1,6 +1,5 @@
-[Google Account]
-email: example@gmail.com
-password: password
+[Authorization]
+credentials_file:
 
 [Spreadsheet]
 id:


### PR DESCRIPTION
Since last weekend, we've been getting significantly higher number of 500 error codes from the Spreadsheet API. These errors are usually transient and retrying helps.
This PR adds a very simple exponential backoff strategy to `HTTPSession` which helped a lot in our case.
Additionally, the test script is slightly modified to work with non-Service Account OAuth2 credentials as well.
