### PR TITLE
Added mechanism to write pandas dataframe to google worksheet

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -10,7 +10,6 @@ This module contains utility functions.
 
 from xml.etree import ElementTree
 
-
 def finditem(func, seq):
     """Finds and returns first item in iterable for which func(item) is True.
 
@@ -87,6 +86,17 @@ def numericise_all(input, empty2zero=False):
     """Returns a list of numericised values from strings"""
     return [numericise(s, empty2zero) for s in input]
 
+def number_to_column(col_number):
+    """Returns spreadsheet column label given a column number
+
+    i.e. 3 -> C, 27 -> AA
+    """
+    if col_number > 26:
+        char1 = chr((col_number // 26)+97).upper()
+        char2 = chr((col_number % 26)+97).upper()
+        return(char1+char2)
+    else:
+        return(chr(col_number+97).upper())
 
 if __name__ == '__main__':
     import doctest

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,6 +6,7 @@ import unittest
 import itertools
 import json
 import uuid
+from pandas import DataFrame
 try:
     import ConfigParser
 except ImportError:
@@ -422,6 +423,20 @@ class WorksheetTest(GspreadTest):
                            for line in exported_data.splitlines()]
 
         self.assertEqual(exported_values, value_list)
+
+    def test_df_import(self):
+        headers = [gen_value(),gen_value()]
+        test_data = [[gen_value(),gen_value()],
+                     [gen_value(),gen_value()],
+                     [gen_value(),gen_value()]]
+
+        test_df = DataFrame(test_data,
+                            columns=headers)
+
+        self.sheet.import_dataframe(test_df)
+        self.assertEqual([headers]+test_data,self.sheet.get_all_values())
+
+
 
 
 class WorksheetDeleteTest(GspreadTest):


### PR DESCRIPTION
I was using gspread to write small-ish pandas dataframes to google sheets and felt it could be a nice feature for folks used to working with dataframes. 

import_dataframe resizes the worksheet to the dimensions of the dataframe it is exporting, replacing any data existing in the worksheet. It will process up to 25,000 rows in its current form - I thought this was a good enough size that it would cover most applications. If there is demand for larger dataframes I'm happy to add some chunking logic (taking into account a worksheet's 2 million cell limit). 