### PR TITLE
Make get_all_records return empty cells as None

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 install: "pip install oauth2client requests[security]"
 script: nosetests -vv tests/mock_tests.py

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -360,7 +360,7 @@ class Worksheet(object):
 
         return [[rows[i][j] for j in rect_cols] for i in rect_rows]
 
-    def get_all_records(self, empty2zero=False, head=1, **kwargs):
+    def get_all_records(self, empty2zero=False, head=1, default_blank=""):
         """Returns a list of dictionaries, all of them having:
             - the contents of the spreadsheet's with the head row as keys,
             And each of these dictionaries holding
@@ -374,14 +374,13 @@ class Worksheet(object):
         :param head: determines wich row to use as keys, starting from 1
             following the numeration of the spreadsheet.
         :param default_blank: determines whether empty cells are converted to
-            something else. Lack of parameter will not convert them, any value
-            (including None) will be used for conversion."""
+            something else except empty string or zero."""
 
         idx = head - 1
 
         data = self.get_all_values()
         keys = data[idx]
-        values = [numericise_all(row, empty2zero, **kwargs)
+        values = [numericise_all(row, empty2zero, default_blank)
                   for row in data[idx + 1:]]
 
         return [dict(zip(keys, row)) for row in values]

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -360,7 +360,7 @@ class Worksheet(object):
 
         return [[rows[i][j] for j in rect_cols] for i in rect_rows]
 
-    def get_all_records(self, empty2zero=False, head=1):
+    def get_all_records(self, empty2zero=False, head=1, **kwargs):
         """Returns a list of dictionaries, all of them having:
             - the contents of the spreadsheet's with the head row as keys,
             And each of these dictionaries holding
@@ -372,13 +372,17 @@ class Worksheet(object):
 
         :param empty2zero: determines whether empty cells are converted to zeros.
         :param head: determines wich row to use as keys, starting from 1
-            following the numeration of the spreadsheet."""
+            following the numeration of the spreadsheet.
+        :param default_blank: determines whether empty cells are converted to
+            something else. Lack of parameter will not convert them, any value
+            (including None) will be used for conversion."""
 
         idx = head - 1
 
         data = self.get_all_values()
         keys = data[idx]
-        values = [numericise_all(row, empty2zero) for row in data[idx + 1:]]
+        values = [numericise_all(row, empty2zero, **kwargs)
+                  for row in data[idx + 1:]]
 
         return [dict(zip(keys, row)) for row in values]
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -46,7 +46,7 @@ def _ds(elem):
     return ElementTree.tostring(elem)
 
 
-def numericise(value, empty2zero=False):
+def numericise(value, empty2zero=False, **kwargs):
     """Returns a value that depends on the input string:
         - Float if input can be converted to Float
         - Integer if input can be converted to integer
@@ -77,15 +77,18 @@ def numericise(value, empty2zero=False):
             try:
                 value = float(value)
             except ValueError:
-                if value == "" and empty2zero:
-                    value = 0
+                if value == "":
+                    if empty2zero:
+                        value = 0
+                    elif kwargs.get('default_blank'):
+                        value = kwargs['default_blank']
 
     return value
 
 
-def numericise_all(input, empty2zero=False):
+def numericise_all(input, empty2zero=False, **kwargs):
     """Returns a list of numericised values from strings"""
-    return [numericise(s, empty2zero) for s in input]
+    return [numericise(s, empty2zero, **kwargs) for s in input]
 
 
 if __name__ == '__main__':

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -46,7 +46,7 @@ def _ds(elem):
     return ElementTree.tostring(elem)
 
 
-def numericise(value, empty2zero=False, **kwargs):
+def numericise(value, empty2zero=False, default_blank=""):
     """Returns a value that depends on the input string:
         - Float if input can be converted to Float
         - Integer if input can be converted to integer
@@ -65,6 +65,10 @@ def numericise(value, empty2zero=False, **kwargs):
     0
     >>> numericise("", empty2zero=False)
     ''
+    >>> numericise("", default_blank=None)
+    >>>
+    >>> numericise("", default_blank="foo")
+    'foo'
     >>> numericise("")
     ''
     >>> numericise(None)
@@ -80,15 +84,15 @@ def numericise(value, empty2zero=False, **kwargs):
                 if value == "":
                     if empty2zero:
                         value = 0
-                    elif kwargs.get('default_blank'):
-                        value = kwargs['default_blank']
+                    else:
+                        value = default_blank
 
     return value
 
 
-def numericise_all(input, empty2zero=False, **kwargs):
+def numericise_all(input, empty2zero=False, default_blank=""):
     """Returns a list of numericised values from strings"""
-    return [numericise(s, empty2zero, **kwargs) for s in input]
+    return [numericise(s, empty2zero, default_blank) for s in input]
 
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -355,6 +355,16 @@ class WorksheetTest(GspreadTest):
         d1 = dict(zip(rows[0], (0, 0, 0, 0)))
         self.assertEqual(read_records[1], d1)
 
+        # then, read empty strings to None
+        read_records = self.sheet.get_all_records(default_blank=None)
+        d1 = dict(zip(rows[0], (None, None, None, None)))
+        self.assertEqual(read_records[1], d1)
+
+        # then, read empty strings to something else
+        read_records = self.sheet.get_all_records(default_blank='foo')
+        d1 = dict(zip(rows[0], ('foo', 'foo', 'foo', 'foo')))
+        self.assertEqual(read_records[1], d1)
+
     def test_get_all_records_different_header(self):
         self.sheet.resize(6, 4)
         # put in new values, made from three lists
@@ -381,6 +391,16 @@ class WorksheetTest(GspreadTest):
         # then, read empty strings to zeros
         read_records = self.sheet.get_all_records(empty2zero=True, head=3)
         d1 = dict(zip(rows[2], (0, 0, 0, 0)))
+        self.assertEqual(read_records[1], d1)
+
+        # then, read empty strings to None
+        read_records = self.sheet.get_all_records(default_blank=None)
+        d1 = dict(zip(rows[2], (None, None, None, None)))
+        self.assertEqual(read_records[1], d1)
+
+        # then, read empty strings to something else
+        read_records = self.sheet.get_all_records(default_blank='foo')
+        d1 = dict(zip(rows[2], ('foo', 'foo', 'foo', 'foo')))
         self.assertEqual(read_records[1], d1)
 
     def test_append_row(self):


### PR DESCRIPTION
Since now `gspread.Worksheet.get_all_records` method can handle parameter default_blank that will be used to convert blank cells to something except empty string (default behavior) or zero (if `empty2zero=True`).