### PR TITLE
Fix error when inserting permissions.

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -374,9 +374,11 @@ class Client(object):
             'sendNotificationEmails': notify,
             'emailMessage': email_message
         }
+        
+        headers = {'Content-Type': 'application/json'}
 
         try:
-            self.session.post(url, json.dumps(data), params=params)
+            self.session.post(url, json.dumps(data), params=params, headers=headers)
         except HTTPError as ex:
             raise RequestError(ex.message)
 


### PR DESCRIPTION
There was an error that the request to insert permissions defaulted to form type, I changed it to be 'application/json' which is accepted by Google.