### PR TITLE
Added ability to copy a spreadsheet

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -242,7 +242,7 @@ class Client(object):
 
         return ElementTree.fromstring(r.content)
 
-    def create(self, title):
+    def create(self,title,copy='no',key=''):
         """Creates a new spreadsheet.
 
         :param title: A title of a new spreadsheet.
@@ -265,6 +265,9 @@ class Client(object):
            when you try to create a new spreadsheet.
 
         """
+        endpoint=DRIVE_FILES_API_V2_URL
+        if copy =='yes':
+            endpoint="https://www.googleapis.com/drive/v2/files/" + key + '/copy'        
 
         headers = {'Content-Type': 'application/json'}
         data = {
@@ -272,7 +275,7 @@ class Client(object):
             'mimeType': 'application/vnd.google-apps.spreadsheet'
         }
         r = self.session.post(
-            DRIVE_FILES_API_V2_URL,
+            endpoint,
             json.dumps(data),
             headers=headers
         )


### PR DESCRIPTION
This requires an additional scope, https://www.googleapis.com/auth/drive:
`scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']`

The existing `create()` function works as normal. This includes two new parameters, `copy` and `key`. Key is the key or file ID of the original spreadsheet (obtained from the URL of the Google Spreadsheet you want to copy from) Example:

`gc = gspread.authorize(creds)`

`n=gc.create(copy='yes',key='key/fileID',title='New spreadsheet (copy)')`

`n.share('you@gmail', perm_type='user', role='writer')`

Thoughts/improvements welcome. Would be nice to have an additional "copy title" option to grab the existing title from the originating file, and append "(copy)" on the new one. Will do that when I get time.
