### PR TITLE
[utils/extract_id_from_url] Adds support for multi-user type urls

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -17,7 +17,7 @@ MAGIC_NUMBER = 64
 CELL_ADDR_RE = re.compile(r'([A-Za-z]+)([1-9]\d*)')
 
 URL_KEY_V1_RE = re.compile(r'key=([^&#]+)')
-URL_KEY_V2_RE = re.compile(r'/spreadsheets/d/([a-zA-Z0-9-_]+)')
+URL_KEY_V2_RE = re.compile(r'/spreadsheets/(?:u/\d+/|)d/([a-zA-Z0-9-_]+)')
 
 
 def finditem(func, seq):

--- a/tests/test.py
+++ b/tests/test.py
@@ -65,6 +65,11 @@ class UtilsTest(unittest.TestCase):
              '1qpyC0X3A0MwQoFDE8p-Bll4hps',
              '1qpyC0X3A0MwQoFDE8p-Bll4hps'),
 
+            # Per-user-style url
+            ('https://docs.google.com/spreadsheets/u/1/d/'
+             '1qpyC0X3A0MwQoFDE8p-Bll4hps',
+             '1qpyC0X3A0MwQoFDE8p-Bll4hps'),
+
             # Old-style url
             ('https://docs.google.com/spreadsheet/'
              'ccc?key=1qpyC0X3A0MwQoFDE8p-Bll4hps&usp=drive_web#gid=0',


### PR DESCRIPTION
Taking a stab at https://github.com/burnash/gspread/issues/490

Adds a test case as well.  Let me know if you prefer adding a new regex because the new "maybe match" is hard to read.