### PR TITLE
Decode request data as utf-8 by default

### DIFF
--- a/gspread/httpsession.py
+++ b/gspread/httpsession.py
@@ -36,7 +36,7 @@ class HTTPSession(object):
 
     def request(self, method, url, data=None, params=None, headers=None, files=None, json=None):
         if data and isinstance(data, bytes):
-            data = data.decode()
+            data = data.decode('utf-8')
 
         if data and not isinstance(data, basestring):
             data = urlencode(data)


### PR DESCRIPTION
Found a problem when trying to upload data containing unicode, and this is a working solution.

**Now**, I can't say I did any sort of proper testing (only Python 2.7.11, no more cases than my one), though as later in the code there is explicitly `data.encode('utf-8')` this doesn't strike me as an immediately stinky solution.