### PR TITLE
Added update_worksheet_format in order to format a worksheet

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -390,6 +390,19 @@ class Client(object):
         headers = {'Content-Type': 'application/json'}
 
         self.session.delete(url, headers=headers)
+        
+    def update_format(self, file_id, data_file):
+        """Updates format of a worksheet.
+
+                :param file_id: a spreadsheet ID (aka file ID.)
+                :param data_file: json with formatting.
+                """
+        headers = {'Content-Type': 'application/json'}
+        with open(data_file) as json_file:
+            data = json.load(json_file)
+        url = construct_url('cells_batch_format', spreadsheet_id=file_id)
+        r = self.session.post(url, json=data, headers=headers)    
+        
 
 
 def authorize(credentials):

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -395,13 +395,11 @@ class Client(object):
         """Updates format of a worksheet.
 
                 :param file_id: a spreadsheet ID (aka file ID.)
-                :param data_file: json with formatting.
+                :param data: dictionary created from json containing formatting details.
                 """
         headers = {'Content-Type': 'application/json'}
-        with open(data_file) as json_file:
-            data = json.load(json_file)
         url = construct_url('cells_batch_format', spreadsheet_id=file_id)
-        r = self.session.post(url, json=data, headers=headers)    
+        self.session.post(url, json=data, headers=headers)    
         
 
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -774,6 +774,13 @@ class Worksheet(object):
         for cell in cells:
             cell.value = ''
         self.update_cells(cells)
+        
+    def update_format_cells(self,sheet_id,json_file ):
+        """Update worksheet format based on a json
+           :param sheet_id the spreadsheet id
+           :param json_file the json file that contains the formatting
+        """
+        self.client.update_format(sheet_id,json_file)
 
 
 class Cell(object):

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -775,12 +775,20 @@ class Worksheet(object):
             cell.value = ''
         self.update_cells(cells)
         
-    def update_format_cells(self,sheet_id,json_file ):
-        """Update worksheet format based on a json
-           :param sheet_id the spreadsheet id
-           :param json_file the json file that contains the formatting
+    def update_worksheet_format(self,json_file):
+        """Updates the worksheet format (i.e cells borders, colors, text font, etc)
+        :param json_file (with path if necessary) is the file that contains the formatting rules
         """
-        self.client.update_format(sheet_id,json_file)
+
+        worksheet_id=self.gid
+        sheet_id = self.spreadsheet.id #it is used to form the link where the json will be POST-ed on
+        with open(json_file) as o_json_file:
+            data=json.load(o_json_file)
+        data_string=str(data)
+        # The worksheet id is specified in the json file using attribute "sheetId"
+        # Any "sheetId" attribute specified in the json will be replaced with the actual worksheet id
+        json_modified=ast.literal_eval(re.sub(r"'sheetId': (\d+)", r"'sheetId': " + str(worksheet_id), data_string))
+        self.client.update_format(sheet_id,json_modified)
 
 
 class Cell(object):

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -7,7 +7,9 @@ gspread.models
 This module contains common spreadsheets' models
 
 """
-
+import json
+import re
+import ast
 from collections import defaultdict
 from itertools import chain
 from functools import wraps

--- a/gspread/urls.py
+++ b/gspread/urls.py
@@ -17,6 +17,7 @@ SPREADSHEETS_API_V3_URL = 'https://spreadsheets.google.com/feeds/'
 DRIVE_FILES_API_V2_URL = 'https://www.googleapis.com/drive/v2/files'
 DRIVE_FILES_UPLOAD_API_V2_URL = ('https://www.googleapis.com'
                                  '/upload/drive/v2/files')
+SPREADSHEETS_API_V4_URL = 'https://sheets.googleapis.com/v4/'
 
 # General pattern
 # /feeds/feedType/key/worksheetId/visibility/projection
@@ -32,13 +33,17 @@ DRIVE_FILES_UPLOAD_API_V2_URL = ('https://www.googleapis.com'
 # Cell-based feed
 # /feeds/cells/key/worksheetId/visibility/projection
 # /feeds/cells/key/worksheetId/visibility/projection/cellId
+#
+# v4API spreadsheet update
+# https://sheets.googleapis.com/v4/spreadsheets/spreadsheetId:batchUpdate 
 
 _feed_types = {'spreadsheets': 'spreadsheets/{visibility}/{projection}',
                'worksheets': 'worksheets/{spreadsheet_id}/{visibility}/{projection}',
                'worksheet': 'worksheets/{spreadsheet_id}/{visibility}/{projection}/{worksheet_id}/{version}',
                'cells': 'cells/{spreadsheet_id}/{worksheet_id}/{visibility}/{projection}',
                'cells_batch': 'cells/{spreadsheet_id}/{worksheet_id}/{visibility}/{projection}/batch',
-               'cells_cell_id': 'cells/{spreadsheet_id}/{worksheet_id}/{visibility}/{projection}/{cell_id}'}
+               'cells_cell_id': 'cells/{spreadsheet_id}/{worksheet_id}/{visibility}/{projection}/{cell_id}',
+               'cells_batch_format': 'spreadsheets/{spreadsheet_id}:batchUpdate'}
 
 _fields_cache = {}
 
@@ -83,7 +88,11 @@ def construct_url(feedtype=None,
     params = dict((k, v) for k, v in params.items() if v is not None)
 
     try:
-        return '%s%s' % (SPREADSHEETS_API_V3_URL,
+        if feedtype == 'cells_batch_format':
+            return '%s%s' % (SPREADSHEETS_API_V4_URL,
+                             urlpattern.format(**params))
+        else:
+            return '%s%s' % (SPREADSHEETS_API_V3_URL,
                          urlpattern.format(**params))
     except KeyError as e:
         raise UrlParameterMissing(e)


### PR DESCRIPTION
Hi @burnash,

Thanks a lot for implementing gspread. I found it really easy to use.
I am currently working with it and I needed to add a method to apply formatting to a worksheet at some point.
I have added it in my local package and I thought to submit it to you, perhaps it helps.
Then I noticed you already have a new branch for api v4 and my modifications are based on the current master.
I haven’t had the time to check the apiv4 branch properly, but if you think my modifications are fine I can fix them to fit in this branch.
Also, I am new to github so I hope I don’t cause any troubles here :)

Anyway I have performed the following:
The formatting is contained in a json file.
I have modified urls.py file to include the URL used in APIv4.
I added update_format method in client.py that performs the POST containing the json as dictionary on the APIv4 url.
I added update_worksheet_format method in models, under worksheet class, that will open the json, modify the worksheet id and pass it as dictionary to the update_format method. This method receives as param the json file name/path.
These modifications appear to work fine for me, even though I am not 100% sure whether the transformations on the json are really reliable :)
Update_format just depends on the spreadsheet id so it can be used to add a method to update the format of the entire spreadsheet.

Regards,
Elinnore

