### PR TITLE
Raise SpreadsheetNotFound in Client.open_by_key if not found

### DIFF
--- a/gspread/v4/client.py
+++ b/gspread/v4/client.py
@@ -122,12 +122,17 @@ class Client(BaseClient):
 
         """
         try:
-            return Spreadsheet(self, {'id': key})
-        except APIError as err:
-            if 'NOT_FOUND' in err:
-                raise SpreadsheetNotFound
-            else:
-                raise err
+            properties = finditem(
+                lambda x: x['id'] == key,
+                self.list_spreadsheet_files()
+            )
+
+            # Drive uses different terminology
+            properties['title'] = properties['name']
+
+            return Spreadsheet(self, properties)
+        except StopIteration:
+            raise SpreadsheetNotFound
 
     def openall(self, title=None):
         """Opens all available spreadsheets.

--- a/gspread/v4/client.py
+++ b/gspread/v4/client.py
@@ -121,7 +121,13 @@ class Client(BaseClient):
         >>> c.open_by_key('0BmgG6nO_6dprdS1MN3d3MkdPa142WFRrdnRRUWl1UFE')
 
         """
-        return Spreadsheet(self, {'id': key})
+        try:
+            return Spreadsheet(self, {'id': key})
+        except APIError as err:
+            if 'NOT_FOUND' in err:
+                raise SpreadsheetNotFound
+            else:
+                raise err
 
     def openall(self, title=None):
         """Opens all available spreadsheets.


### PR DESCRIPTION
I catch this exception on https://github.com/aiguofer/gspread-pandas to let users pass in Title, URL, or ID and cascade through methods until it succeeds.