### PR TITLE
Support cell formats (using v4 JSON API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,32 @@ for cell in cell_list:
 worksheet.update_cells(cell_list)
 ```
 
+### Formatting Cells
+
+Basic formatting of a range of cells is supported. All basic formatting components 
+of the v4 Sheets API's `CellFormat` are present as classes in the `gspread.format` module, 
+available both by `InitialCaps` names and `camelCase` names: for example, the background color 
+class is `BackgroundColor` but is also available as `backgroundColor`, while the color class is `Color`
+but available also as `color`. Attributes of formatting components are best specified as 
+keyword arguments using `camelCase` naming, e.g. `backgroundColor=...`. Complex formats 
+may be composed easily, by nesting the calls to the classes.  
+
+See [the CellFormat page of the Sheets API documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#CellFormat) 
+to learn more about each formatting component.
+
+```python
+
+from gspread.format import *
+
+fmt = cellFormat(
+    backgroundColor=color(1, 0.9, 0.9),
+    textFormat=textFormat(bold=True, foregroundColor=color(1, 0, 1)),
+    horizontalAlignment='CENTER'
+    )
+
+ws.format_range('A1:J1', fmt)
+```
+
 ## Installation
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -198,6 +198,25 @@ fmt = cellFormat(
 ws.format_range('A1:J1', fmt)
 ```
 
+`CellFormat` objects are comparable with `==` and `!=`, and are mutable at all times; 
+they can be safely copied with `copy.deepcopy`. `CellFormat` objects can be combined
+into a new `CellFormat` object using the `add` method (or `+` operator). `CellFormat` objects also offer 
+`difference` and `intersection` methods, as well as the corresponding
+operators `-` (for difference) and `&` (for intersection). An example:
+
+```python
+
+>>> default_format = CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True))
+>>> user_format = CellFormat(textFormat=textFormat(italic=True))
+>>> effective_format = default_format + user_format
+>>> effective_format
+CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True, italic=True))
+>>> effective_format - user_format 
+CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True))
+>>> effective_format - user_format == default_format
+True
+```
+
 ## Installation
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True))
 True
 ```
 
+The spreadsheet's own default format, as a CellFormat object, is available via `Spreadsheet.default_format`.
+`Worksheet.get_effective_format(label)` and `Worksheet.get_user_entered_format(label)` also will return
+for any provided cell label either a CellFormat object (if any formatting is present) or None.
+
+
 ## Installation
 
 ### Requirements

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -2,20 +2,13 @@
 
 import re
 
-def convert_to_cell_format(value):
-    """
-    :param: value: the dictionary object parsed from the JSON body of an API response
-    :returns: a CellFormat object
-    """
-    return _json_to_component('cellFormat', value)
-
-def _json_to_component(class_alias, value):
+def _props_to_component(class_alias, value):
     if class_alias not in _CLASSES:
         raise ValueError("No format component named '%s'" % class_alias)
     kwargs = {}
     for k, v in value.items():
         if isinstance(v, dict):
-            v = _json_to_component(k, v)
+            v = _props_to_component(k, v)
         kwargs[k] = v
     return _CLASSES[class_alias](**kwargs)
 
@@ -24,7 +17,6 @@ def _ul_repl(m):
 
 def _underlower(name):
     return name[0].lower() + name[1:]
-    #return name[0].lower() + re.sub(r'([A-Z])', _ul_repl, name[1:])
 
 def _parse_string_enum(name, value, set_of_values, required=False):
     if value is None and required:
@@ -48,6 +40,10 @@ def _extract_fieldrefs(name, value, prefix):
 
 class CellFormatComponent(object):
     _FIELDS = ()
+
+    @classmethod
+    def from_props(cls, props):
+        return _props_to_component(_underlower(cls.__name__), props)
 
     def __repr__(self):
         return '<' + self.__class__.__name__ + ' ' + str(self) + '>'

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -2,6 +2,23 @@
 
 import re
 
+def convert_to_cell_format(value):
+    """
+    :param: value: the dictionary object parsed from the JSON body of an API response
+    :returns: a CellFormat object
+    """
+    return _json_to_component('cellFormat', value)
+
+def _json_to_component(class_alias, value):
+    if class_alias not in _CLASSES:
+        raise ValueError("No format component named '%s'" % class_alias)
+    kwargs = {}
+    for k, v in value.items():
+        if isinstance(v, dict):
+            v = _json_to_component(k, v)
+        kwargs[k] = v
+    return _CLASSES[class_alias](**kwargs)
+
 def _ul_repl(m):
     return '_' + m.group(1).lower()
 
@@ -172,6 +189,9 @@ class TextRotation(CellFormatComponent):
 
 # provide camelCase aliases for all component classes.
 
+_CLASSES = {}
 for _c in [ obj for name, obj in locals().items() if isinstance(obj, type) and issubclass(obj, CellFormatComponent) ]:
-    locals()[_underlower(_c.__name__)] = _c
+    _k = _underlower(_c.__name__)
+    _CLASSES[_k] = _c
+    locals()[_k] = _c
 

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -1,0 +1,236 @@
+import re
+
+def _ul_repl(m):
+    return '_' + m.group(1).lower()
+
+def _underlower(name):
+    return name[0].lower() + name[1:]
+    #return name[0].lower() + re.sub(r'([A-Z])', _ul_repl, name[1:])
+
+def _parse_string_enum(name, value, set_of_values, required=False):
+    if value is None and required:
+        raise ValueError("%s value is required" % name)
+    if value is not None and value.upper() not in set_of_values:
+        raise ValueError("%s value must be one of: %s" % (name, set_of_values))
+    return value.upper() if value is not None else None
+
+def _extract_props(value):
+    if hasattr(value, 'to_props'):
+        return value.to_props()
+    return value
+
+def _extract_fieldrefs(name, value, prefix):
+    if hasattr(value, 'affected_fields'):
+        return value.affected_fields(".".join([prefix, name]))
+    elif value is not None:
+        return [".".join([prefix, name])]
+    else:
+        return []
+
+class CellFormatComponent(object):
+    pass
+
+class CellFormat(CellFormatComponent):
+    def __init__(self, 
+        number_format=None,
+        backgroundColor=None,
+        borders=None,
+        padding=None,
+        horizontalAlignment=None,
+        verticalAlignment=None,
+        wrapStrategy=None,
+        textDirection=None,
+        textFormat=None,
+        hyperlinkDisplayType=None,
+        textRotation=None
+        ):
+        self.number_format = number_format
+        self.backgroundColor = backgroundColor
+        self.borders = borders
+        self.padding = padding
+        self.horizontalAlignment = _parse_string_enum('horizontalAlignment', horizontalAlignment, {'LEFT', 'CENTER', 'RIGHT'})
+        self.verticalAlignment = _parse_string_enum('verticalAlignment', verticalAlignment, {'TOP', 'MIDDLE', 'BOTTOM'})
+        self.wrapStrategy = _parse_string_enum('wrapStrategy', wrapStrategy, {'OVERFLOW_CELL', 'LEGACY_WRAP', 'CLIP', 'WRAP'})
+        self.textDirection = _parse_string_enum('textDirection', textDirection, {'LEFT_TO_RIGHT', 'RIGHT_TO_LEFT'})
+        self.textFormat = textFormat
+        self.hyperlinkDisplayType = _parse_string_enum('hyperlinkDisplayType', hyperlinkDisplayType, {'LINKED', 'PLAIN_TEXT'})
+        self.textRotation = textRotation
+
+    def to_props(self):
+        p = {}
+        for a in (
+            'number_format', 'backgroundColor', 'borders', 'padding', 
+            'horizontalAlignment', 'verticalAlignment', 'wrapStrategy', 
+            'textDirection', 'textFormat', 'hyperlinkDisplayType', 'textRotation'):
+            if getattr(self, a) is not None:
+                p[a] = _extract_props(getattr(self, a))
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in (
+            'number_format', 'backgroundColor', 'borders', 'padding', 
+            'horizontalAlignment', 'verticalAlignment', 'wrapStrategy', 
+            'textDirection', 'textFormat', 'hyperlinkDisplayType', 'textRotation'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+
+class NumberFormat(CellFormatComponent):
+    TYPES = {'TEXT', 'NUMBER', 'PERCENT', 'CURRENCY', 'DATE', 'TIME', 'DATE_TIME', 'SCIENTIFIC'}
+
+    def __init__(self, type, pattern=None):
+        if type.upper() not in TYPES:
+            raise ValueError("NumberFormat.type must be one of: %s" % TYPES)
+        self.type = type.upper()
+        self.pattern = pattern
+
+    def to_props(self):
+        p = { 'type': self.type }
+        if self.pattern:
+            p['pattern'] = self.pattern
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        fields.extend( _extract_fieldrefs('type', self.type, prefix) )
+        fields.extend( _extract_fieldrefs('pattern', self.pattern, prefix) )
+        return fields
+
+class Color(CellFormatComponent):
+    def __init__(self, red, green, blue, alpha=None):
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.alpha = alpha
+
+    def to_props(self):
+        p = { 'red': self.red, 'blue': self.blue, 'green': self.green }
+        if self.alpha is not None:
+            p['alpha'] = self.alpha
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in ('red', 'green', 'blue', 'alpha'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+class Borders(CellFormatComponent):
+    def __init__(self, top=None, bottom=None, left=None, right=None):
+        self.top = top
+        self.bottom = bottom
+        self.left = left
+        self.right = right
+
+    def to_props(self):
+        p = {}
+        for a in ('top', 'bottom', 'left', 'right'):
+            if getattr(self, a) is not None:
+                p[a] = _extract_props(getattr(self, a))
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in ('top', 'bottom', 'left', 'right'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+class Border(CellFormatComponent):
+    STYLES = {'DOTTED', 'DASHED', 'SOLID', 'SOLID_MEDIUM', 'SOLID_THICK', 'NONE', 'DOUBLE'}
+
+    def __init__(self, style, color):
+        if style.upper() not in STYLES:
+            raise ValueError("Border.style must be one of: %s" % STYLES)
+        self.style = style.upper()
+        self.color = color
+
+    def to_props(self):
+        p = { 'style': self.style }
+        if self.color:
+            p['color'] = _extract_props(self.color)
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in ('style', 'color'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+class Padding(CellFormatComponent):
+    def __init__(self, top=None, right=None, bottom=None, left=None):
+        self.top = top
+        self.right = right
+        self.bottom = bottom
+        self.left = left
+
+    def to_props(self):
+        p = {}
+        for a in ('top', 'right', 'bottom', 'left'):
+            if getattr(self, a) is not None:
+                p[a] = getattr(self, a)
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in ('top', 'right', 'bottom', 'left'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+class TextFormat(CellFormatComponent):
+    def __init__(self, 
+        foregroundColor=None, 
+        fontFamily=None, 
+        fontSize=None, 
+        bold=None, 
+        italic=None, 
+        strikethrough=None, 
+        underline=None
+        ):
+        self.foregroundColor = foregroundColor
+        self.fontFamily = fontFamily
+        self.fontSize = fontSize
+        self.bold = bold
+        self.italic = italic
+        self.strikethrough = strikethrough
+        self.underline = underline
+
+    def to_props(self):
+        p = {}
+        for a in ('foregroundColor', 'fontFamily', 'fontSize', 'bold', 'italic', 'strikethrough', 'underline'):
+            if getattr(self, a) is not None:
+                p[a] = _extract_props(getattr(self, a))
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in ('foregroundColor', 'fontFamily', 'fontSize', 'bold', 'italic', 'strikethrough', 'underline'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+class TextRotation(CellFormatComponent):
+    def __init__(self, angle=None, vertical=None):
+        if len([expr for expr in (angle is not None, vertical is not None) if expr]) != 1:
+            raise ValueError("Either angle or vertical must be specified, not both or neither")
+        self.angle = angle
+        self.vertical = vertical
+
+    def to_props(self):
+        return { 'angle': self.angle } if self.angle is not None else { 'vertical': self.vertical }
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in ('angle', 'vertical'):
+            if getattr(self, a) is not None:
+                fields.extend( _extract_fieldrefs(a, getattr(self, a), prefix) )
+        return fields
+
+for _c in [ obj for name, obj in locals().items() if isinstance(obj, type) and issubclass(obj, CellFormatComponent) ]:
+    locals()[_underlower(_c.__name__)] = _c
+

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -158,18 +158,18 @@ class CellFormat(CellFormatComponent):
         self.backgroundColor = backgroundColor
         self.borders = borders
         self.padding = padding
-        self.horizontalAlignment = _parse_string_enum('horizontalAlignment', horizontalAlignment, {'LEFT', 'CENTER', 'RIGHT'})
-        self.verticalAlignment = _parse_string_enum('verticalAlignment', verticalAlignment, {'TOP', 'MIDDLE', 'BOTTOM'})
-        self.wrapStrategy = _parse_string_enum('wrapStrategy', wrapStrategy, {'OVERFLOW_CELL', 'LEGACY_WRAP', 'CLIP', 'WRAP'})
-        self.textDirection = _parse_string_enum('textDirection', textDirection, {'LEFT_TO_RIGHT', 'RIGHT_TO_LEFT'})
+        self.horizontalAlignment = _parse_string_enum('horizontalAlignment', horizontalAlignment, set(['LEFT', 'CENTER', 'RIGHT']))
+        self.verticalAlignment = _parse_string_enum('verticalAlignment', verticalAlignment, set(['TOP', 'MIDDLE', 'BOTTOM']))
+        self.wrapStrategy = _parse_string_enum('wrapStrategy', wrapStrategy, set(['OVERFLOW_CELL', 'LEGACY_WRAP', 'CLIP', 'WRAP']))
+        self.textDirection = _parse_string_enum('textDirection', textDirection, set(['LEFT_TO_RIGHT', 'RIGHT_TO_LEFT']))
         self.textFormat = textFormat
-        self.hyperlinkDisplayType = _parse_string_enum('hyperlinkDisplayType', hyperlinkDisplayType, {'LINKED', 'PLAIN_TEXT'})
+        self.hyperlinkDisplayType = _parse_string_enum('hyperlinkDisplayType', hyperlinkDisplayType, set(['LINKED', 'PLAIN_TEXT']))
         self.textRotation = textRotation
 
 class NumberFormat(CellFormatComponent):
     _FIELDS = ('type', 'pattern')
 
-    TYPES = {'TEXT', 'NUMBER', 'PERCENT', 'CURRENCY', 'DATE', 'TIME', 'DATE_TIME', 'SCIENTIFIC'}
+    TYPES = set(['TEXT', 'NUMBER', 'PERCENT', 'CURRENCY', 'DATE', 'TIME', 'DATE_TIME', 'SCIENTIFIC'])
 
     def __init__(self, type, pattern=None):
         if type.upper() not in TYPES:
@@ -198,7 +198,7 @@ class Borders(CellFormatComponent):
 class Border(CellFormatComponent):
     _FIELDS = ('style', 'color')
 
-    STYLES = {'DOTTED', 'DASHED', 'SOLID', 'SOLID_MEDIUM', 'SOLID_THICK', 'NONE', 'DOUBLE'}
+    STYLES = set(['DOTTED', 'DASHED', 'SOLID', 'SOLID_MEDIUM', 'SOLID_THICK', 'NONE', 'DOUBLE'])
 
     def __init__(self, style, color):
         if style.upper() not in STYLES:

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -126,6 +126,8 @@ class CellFormatComponent(object):
                 this_v = self_v if other_v is None else other_v
             elif isinstance(self_v, CellFormatComponent):
                 this_v = self_v.difference(other_v)
+            elif other_v != self_v:
+                this_v = self_v
             if this_v is not None:
                 new_props[a] = _extract_props(this_v)
         return self.__class__.from_props(new_props) if new_props else None

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -125,9 +125,7 @@ class CellFormatComponent(object):
             self_v = getattr(self, a, None)
             other_v = getattr(other, a, None)
             this_v = None
-            if (self_v is None or other_v is None) and self_v is not other_v:
-                this_v = self_v if other_v is None else other_v
-            elif isinstance(self_v, CellFormatComponent):
+            if isinstance(self_v, CellFormatComponent):
                 this_v = self_v.difference(other_v)
             elif other_v != self_v:
                 this_v = self_v

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 
 def _ul_repl(m):
@@ -167,6 +169,8 @@ class TextRotation(CellFormatComponent):
             raise ValueError("Either angle or vertical must be specified, not both or neither")
         self.angle = angle
         self.vertical = vertical
+
+# provide camelCase aliases for all component classes.
 
 for _c in [ obj for name, obj in locals().items() if isinstance(obj, type) and issubclass(obj, CellFormatComponent) ]:
     locals()[_underlower(_c.__name__)] = _c

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -83,6 +83,9 @@ class CellFormatComponent(object):
                 return False
         return True
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def add(self, other):
         new_props = {}
         for a in self._FIELDS:

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -119,7 +119,7 @@ class NumberFormat(CellFormatComponent):
 class Color(CellFormatComponent):
     _FIELDS = ('red', 'green', 'blue', 'alpha')
 
-    def __init__(self, red, green, blue, alpha=None):
+    def __init__(self, red=None, green=None, blue=None, alpha=None):
         self.red = red
         self.green = green
         self.blue = blue
@@ -190,4 +190,6 @@ for _c in [ obj for name, obj in locals().items() if isinstance(obj, type) and i
     _k = _underlower(_c.__name__)
     _CLASSES[_k] = _c
     locals()[_k] = _c
+_CLASSES['foregroundColor'] = Color
+_CLASSES['backgroundColor'] = Color
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -647,10 +647,15 @@ class Worksheet(object):
         return data
 
     def resize(self, rows=None, cols=None, frozen_rows=None, frozen_cols=None):
-        """Resizes the worksheet.
+        """Resizes the worksheet. Only the arguments provided will be
+        applied to the worksheet; for example, `resize(rows=1000)` will 
+        update only the number of rows, while `resize(frozen_rows=1)` will
+        update only the number of frozen rows.
 
-        :param rows: New rows number.
-        :param cols: New columns number.
+        :param rows: Optionally, the new number of rows in the worksheet.
+        :param cols: Optionally, the new number of columns in the worksheet.
+        :param frozen_rows: Optionally, the number of rows to "freeze" on the worksheet.
+        :param frozen_cols: Optionally, the number of columns to "freeze" on the worksheet.
         """
         grid_properties = {}
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -435,6 +435,54 @@ class Worksheet(object):
         }
         return self.spreadsheet.batch_update(body)
 
+    def get_effective_format(self, label):
+        """Returns a CellFormat object or None representing the effective formatting directives,
+        if any, for the cell; that is a combination of default formatting, user-entered formatting,
+        and conditional formatting.
+
+        :param label: String with cell label in common format, e.g. 'B1'.
+                      Letter case is ignored.
+        Example:
+
+        >>> worksheet.get_user_entered_format('A1')
+        <CellFormat textFormat=(bold=True)>
+        >>> worksheet.get_user_entered_format('A2')
+        None
+        """
+        label = '%s!%s' % (self.title, rowcol_to_a1(*a1_to_rowcol(label)))
+
+        resp = self.spreadsheet.fetch_sheet_metadata({
+            'includeGridData': True,
+            'ranges': [label], 
+            'fields': 'sheets.data.rowData.values.effectiveFormat'
+        })
+        props = resp['sheets'][0]['data'][0]['rowData'][0]['values'][0].get('effectiveFormat')
+        return CellFormat.from_props(props) if props else None
+
+    def get_user_entered_format(self, label):
+        """Returns a CellFormat object or None representing the user-entered formatting directives,
+        if any, for the cell.
+
+        :param label: String with cell label in common format, e.g. 'B1'.
+                      Letter case is ignored.
+        Example:
+
+        >>> worksheet.get_user_entered_format('A1')
+        <CellFormat textFormat=(bold=True)>
+        >>> worksheet.get_user_entered_format('A2')
+        None
+        """
+        label = '%s!%s' % (self.title, rowcol_to_a1(*a1_to_rowcol(label)))
+
+        resp = self.spreadsheet.fetch_sheet_metadata({
+            'includeGridData': True,
+            'ranges': [label], 
+            'fields': 'sheets.data.rowData.values.userEnteredFormat'
+        })
+        props = resp['sheets'][0]['data'][0]['rowData'][0]['values'][0].get('userEnteredFormat')
+        return CellFormat.from_props(props) if props else None
+
+
     @cast_to_a1_notation
     def range(self, name):
         """Returns a list of :class:`Cell` objects from a specified range.

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -116,8 +116,9 @@ class Spreadsheet(object):
         r = self.client.request('put', url, params=params, json=body)
         return r.json()
 
-    def fetch_sheet_metadata(self):
-        params = {'includeGridData': 'false'}
+    def fetch_sheet_metadata(self, params=None):
+        if params is None:
+            params = {'includeGridData': 'false'}
 
         url = SPREADSHEET_URL % self.id
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -22,7 +22,8 @@ from .utils import (
     numericise_all,
     finditem,
     fill_gaps,
-    cell_list_to_rect
+    cell_list_to_rect,
+    range_to_gridrange_object
 )
 
 from .urls import (
@@ -410,22 +411,10 @@ class Worksheet(object):
         :param cell_format: A models.CellFormat object.
         """
 
-        range_label = '%s!%s' % (self.title, name)
-
-        start, end = name.split(':')
-        (row_offset, column_offset) = a1_to_rowcol(start)
-        (last_row, last_column) = a1_to_rowcol(end)
-
         body = {
             'requests': [{
                 'repeatCell': {
-                    'range': {
-                        'sheetId': self.id,
-                        'startRowIndex': row_offset-1,
-                        'endRowIndex': last_row,
-                        'startColumnIndex': column_offset-1,
-                        'endColumnIndex': last_column
-                    },
+                    'range': range_to_gridrange_object(name, self.id),
                     'cell': { 'userEnteredFormat': cell_format.to_props() },
                     'fields': ",".join(cell_format.affected_fields('userEnteredFormat'))
                 }

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -229,6 +229,19 @@ def cell_list_to_rect(cell_list):
 
     return [[rows[i][j] for j in rect_cols] for i in rect_rows]
 
+def range_to_gridrange_object(range, worksheet_id):
+    parts = range.split(':')
+    start = parts[0]
+    end = parts[1] if len(parts) > 1 else ''
+    (row_offset, column_offset) = a1_to_rowcol(start)
+    (last_row, last_column) = a1_to_rowcol(end) if end else (row_offset, column_offset)
+    return {
+        'sheetId': worksheet_id,
+        'startRowIndex': row_offset-1,
+        'endRowIndex': last_row,
+        'startColumnIndex': column_offset-1,
+        'endColumnIndex': last_column
+    }
 
 if __name__ == '__main__':
     import doctest

--- a/tests/test.py
+++ b/tests/test.py
@@ -611,6 +611,7 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(effective_format.difference(fmt), def_fmt)
         self.assertEqual(effective_format.intersection(effective_format), effective_format)
         self.assertEqual(effective_format & effective_format, effective_format)
+        self.assertEqual(effective_format - effective_format, None)
 
 class WorksheetDeleteTest(GspreadTest):
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -595,7 +595,8 @@ class WorksheetTest(GspreadTest):
         fmt = cellFormat(textFormat=textFormat(bold=True))
         self.sheet.format_range('A1:D6', fmt)
         md = self.spreadsheet.fetch_sheet_metadata({'includeGridData': True, 'ranges': ['{}!A1'.format(self.sheet.title)]})
-        ue_fmt = convert_to_cell_format(md['sheets'][0]['data'][0]['rowData'][0]['values'][0]['userEnteredFormat'])
+        props = md['sheets'][0]['data'][0]['rowData'][0]['values'][0]['userEnteredFormat']
+        ue_fmt = cellFormat.from_props(props)
         self.assertEqual(ue_fmt.textFormat.bold, True)
 
 class WorksheetDeleteTest(GspreadTest):

--- a/tests/test.py
+++ b/tests/test.py
@@ -587,6 +587,7 @@ class WorksheetTest(GspreadTest):
                 ["", "", "", ""],
                 ["A4", 0.4, "", 4]]
 
+        def_fmt = self.spreadsheet.default_format
         cell_list = self.sheet.range('A1:D6')
         for cell, value in zip(cell_list, itertools.chain(*rows)):
             cell.value = value

--- a/tests/test.py
+++ b/tests/test.py
@@ -600,6 +600,18 @@ class WorksheetTest(GspreadTest):
         ue_fmt = cellFormat.from_props(props)
         self.assertEqual(ue_fmt.textFormat.bold, True)
 
+    def test_formats_equality_and_arithmetic(self):
+        def_fmt = cellFormat(backgroundColor=Color(1,0,1),textFormat=textFormat(italic=False))
+        fmt = cellFormat(textFormat=textFormat(bold=True))
+        effective_format = def_fmt + fmt
+        self.assertEqual(effective_format.textFormat.bold, True)
+        effective_format2 = def_fmt + fmt
+        self.assertEqual(effective_format, effective_format2)
+        self.assertEqual(effective_format - fmt, def_fmt)
+        self.assertEqual(effective_format.difference(fmt), def_fmt)
+        self.assertEqual(effective_format.intersection(effective_format), effective_format)
+        self.assertEqual(effective_format & effective_format, effective_format)
+
 class WorksheetDeleteTest(GspreadTest):
 
     def setUp(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -595,8 +595,8 @@ class WorksheetTest(GspreadTest):
         fmt = cellFormat(textFormat=textFormat(bold=True))
         self.sheet.format_range('A1:D6', fmt)
         md = self.spreadsheet.fetch_sheet_metadata({'includeGridData': True, 'ranges': ['{}!A1'.format(self.sheet.title)]})
-        self.assertEqual(md['sheets'][0]['data'][0]['rowData'][0]['values'][0]['userEnteredFormat']['textFormat']['bold'], True)
-
+        ue_fmt = convert_to_cell_format(md['sheets'][0]['data'][0]['rowData'][0]['values'][0]['userEnteredFormat'])
+        self.assertEqual(ue_fmt.textFormat.bold, True)
 
 class WorksheetDeleteTest(GspreadTest):
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -350,6 +350,22 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(grid_props['rowCount'], new_rows)
         self.assertEqual(grid_props['columnCount'], new_cols)
 
+        frozen_rows = 1
+        frozen_cols = 1
+        self.sheet.resize(frozen_rows=frozen_rows, frozen_cols=frozen_cols)
+
+        grid_props = get_grid_props()
+
+        self.assertEqual(grid_props['frozenRowCount'], frozen_rows)
+        self.assertEqual(grid_props['frozenColumnCount'], frozen_cols)
+
+        self.sheet.resize(frozen_rows=0, frozen_cols=0)
+
+        grid_props = get_grid_props()
+
+        self.assertEqual(grid_props['frozenRowCount'], 0)
+        self.assertEqual(grid_props['frozenColumnCount'], 0)
+
     def test_find(self):
         value = gen_value()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -595,10 +595,10 @@ class WorksheetTest(GspreadTest):
 
         fmt = cellFormat(textFormat=textFormat(bold=True))
         self.sheet.format_range('A1:D6', fmt)
-        md = self.spreadsheet.fetch_sheet_metadata({'includeGridData': True, 'ranges': ['{}!A1'.format(self.sheet.title)]})
-        props = md['sheets'][0]['data'][0]['rowData'][0]['values'][0]['userEnteredFormat']
-        ue_fmt = cellFormat.from_props(props)
+        ue_fmt = self.sheet.get_user_entered_format('A1')
         self.assertEqual(ue_fmt.textFormat.bold, True)
+        eff_fmt = self.sheet.get_effective_format('A1')
+        self.assertEqual(eff_fmt.textFormat.bold, True)
 
     def test_formats_equality_and_arithmetic(self):
         def_fmt = cellFormat(backgroundColor=Color(1,0,1),textFormat=textFormat(italic=False))


### PR DESCRIPTION
Fixes burnash/gspread#531.

Supports all basic formatting directives for cells, via new `format_range()` method on Worksheet.

I've included full test coverage of the added method and property accessors. And a section added to README.