### PR TITLE
Bugfix 538: default cell values to None instead of empty string

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -595,8 +595,8 @@ class Worksheet(object):
 
         values_rect = cell_list_to_rect(cell_list)
 
-        start = rowcol_to_a1(cell_list[0].row, cell_list[0].col)
-        end = rowcol_to_a1(cell_list[-1].row, cell_list[-1].col)
+        start = rowcol_to_a1(min(c.row for c in cell_list), min(c.col for c in cell_list))
+        end = rowcol_to_a1(max(c.row for c in cell_list), max(c.col for c in cell_list))
 
         range_label = '%s!%s:%s' % (self.title, start, end)
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -211,13 +211,13 @@ def cell_list_to_rect(cell_list):
     if not cell_list:
         return []
 
-    rows = defaultdict(lambda: defaultdict(str))
+    rows = defaultdict(lambda: {})
 
     row_offset = cell_list[0].row
     col_offset = cell_list[0].col
 
     for cell in cell_list:
-        row = rows.setdefault(int(cell.row) - row_offset, defaultdict(str))
+        row = rows.setdefault(int(cell.row) - row_offset, {})
         row[cell.col - col_offset] = cell.value
 
     if not rows:
@@ -227,7 +227,11 @@ def cell_list_to_rect(cell_list):
     rect_cols = range(max(all_row_keys) + 1)
     rect_rows = range(max(rows.keys()) + 1)
 
-    return [[rows[i][j] for j in rect_cols] for i in rect_rows]
+    # Return the values of the cells as a list of lists where each sublist
+    # contains all of the values for one row. The Google API requires a rectangle
+    # of updates, so if a cell isn't present in the input cell_list, then the
+    # value will be None and will not be updated.
+    return [[rows[i].get(j) for j in rect_cols] for i in rect_rows]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#538 

The google API specifies that if the cell `value` is None then no updates will happen in the sheet. Thus, I swapped out the defaultdicts for regular dictionaries and used `.get` for accessing the values (thereby defaulting to None instead of an empty string).