### PR TITLE
Fix usage of client.openall when a title is passed in

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -170,8 +170,9 @@ class Client(object):
         spreadsheet_files = self.list_spreadsheet_files()
 
         if title:
-            spreadsheet_files = [spread for spread in spreadsheet_files
-                                 if title.lower() in spread['name'].lower()]
+            spreadsheet_files = [
+                spread for spread in spreadsheet_files if title == spread["name"]
+            ]
 
         return [
             Spreadsheet(self, dict(title=x['name'], **x))

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -169,6 +169,10 @@ class Client(object):
         """
         spreadsheet_files = self.list_spreadsheet_files()
 
+        if title:
+            spreadsheet_files = [spread for spread in spreadsheet_files
+                                 if title.lower() in spread['name'].lower()]
+
         return [
             Spreadsheet(self, dict(title=x['name'], **x))
             for x in spreadsheet_files

--- a/tests/test.py
+++ b/tests/test.py
@@ -149,7 +149,12 @@ class ClientTest(GspreadTest):
 
     def test_openall(self):
         spreadsheet_list = self.gc.openall()
+        spreadsheet_list2 = self.gc.openall(spreadsheet_list[0].title)
+
+        self.assertTrue(len(spreadsheet_list2) < len(spreadsheet_list))
         for s in spreadsheet_list:
+            self.assertTrue(isinstance(s, gspread.models.Spreadsheet))
+        for s in spreadsheet_list2:
             self.assertTrue(isinstance(s, gspread.models.Spreadsheet))
 
     def test_create(self):


### PR DESCRIPTION
This allows user to get all spreadsheets that contain (case
insensitive) the string that is passed in.