### PR TITLE
Out of order Cell list cause update_cells to fail

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 119

--- a/README.md
+++ b/README.md
@@ -172,6 +172,45 @@ for cell in cell_list:
 worksheet.update_cells(cell_list)
 ```
 
+### Formatting Cells
+ Basic formatting of a range of cells is supported. All basic formatting components 
+of the v4 Sheets API's `CellFormat` are present as classes in the `gspread.format` module, 
+available both by `InitialCaps` names and `camelCase` names: for example, the background color 
+class is `BackgroundColor` but is also available as `backgroundColor`, while the color class is `Color`
+but available also as `color`. Attributes of formatting components are best specified as 
+keyword arguments using `camelCase` naming, e.g. `backgroundColor=...`. Complex formats 
+may be composed easily, by nesting the calls to the classes.  
+ See [the CellFormat page of the Sheets API documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#CellFormat) 
+to learn more about each formatting component.
+ ```python
+ from gspread.format import *
+ fmt = cellFormat(
+    backgroundColor=color(1, 0.9, 0.9),
+    textFormat=textFormat(bold=True, foregroundColor=color(1, 0, 1)),
+    horizontalAlignment='CENTER'
+    )
+ ws.format_range('A1:J1', fmt)
+```
+ `CellFormat` objects are comparable with `==` and `!=`, and are mutable at all times; 
+they can be safely copied with `copy.deepcopy`. `CellFormat` objects can be combined
+into a new `CellFormat` object using the `add` method (or `+` operator). `CellFormat` objects also offer 
+`difference` and `intersection` methods, as well as the corresponding
+operators `-` (for difference) and `&` (for intersection). An example:
+ ```python
+ >>> default_format = CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True))
+>>> user_format = CellFormat(textFormat=textFormat(italic=True))
+>>> effective_format = default_format + user_format
+>>> effective_format
+CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True, italic=True))
+>>> effective_format - user_format 
+CellFormat(backgroundColor=color(1,1,1), textFormat=textFormat(bold=True))
+>>> effective_format - user_format == default_format
+True
+```
+ The spreadsheet's own default format, as a CellFormat object, is available via `Spreadsheet.default_format`.
+`Worksheet.get_effective_format(label)` and `Worksheet.get_user_entered_format(label)` also will return
+for any provided cell label either a CellFormat object (if any formatting is present) or None.
+
 ## Installation
 
 ### Requirements

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -9,7 +9,7 @@ Google Spreadsheets client library.
 """
 
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 __author__ = 'Anton Burnashev'
 
 

--- a/gspread/format.py
+++ b/gspread/format.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+
+
+def _props_to_component(class_alias, value):
+    if class_alias not in _CLASSES:
+        raise ValueError("No format component named '%s'" % class_alias)
+    kwargs = {}
+    for k, v in value.items():
+        if isinstance(v, dict):
+            v = _props_to_component(k, v)
+        kwargs[k] = v
+    return _CLASSES[class_alias](**kwargs)
+
+
+def _ul_repl(m):
+    return '_' + m.group(1).lower()
+
+
+def _underlower(name):
+    return name[0].lower() + name[1:]
+
+
+def _parse_string_enum(name, value, set_of_values, required=False):
+    if value is None and required:
+        raise ValueError("%s value is required" % name)
+    if value is not None and value.upper() not in set_of_values:
+        raise ValueError("%s value must be one of: %s" % (name, set_of_values))
+    return value.upper() if value is not None else None
+
+
+def _extract_props(value):
+    if hasattr(value, 'to_props'):
+        return value.to_props()
+    return value
+
+
+def _extract_fieldrefs(name, value, prefix):
+    if hasattr(value, 'affected_fields'):
+        return value.affected_fields(".".join([prefix, name]))
+    elif value is not None:
+        return [".".join([prefix, name])]
+    else:
+        return []
+
+
+class CellFormatComponent(object):
+    _FIELDS = ()
+
+    @classmethod
+    def from_props(cls, props):
+        return _props_to_component(_underlower(cls.__name__), props)
+
+    def __repr__(self):
+        return '<' + self.__class__.__name__ + ' ' + str(self) + '>'
+
+    def __str__(self):
+        p = []
+        for a in self._FIELDS:
+            v = getattr(self, a)
+            if v is not None:
+                if isinstance(v, CellFormatComponent):
+                    p.append((a, "(" + str(v) + ")"))
+                else:
+                    p.append((a, str(v)))
+        return ";".join(["%s=%s" % (k, v) for k, v in p])
+
+    def to_props(self):
+        p = {}
+        for a in self._FIELDS:
+            if getattr(self, a) is not None:
+                p[a] = _extract_props(getattr(self, a))
+        return p
+
+    def affected_fields(self, prefix):
+        fields = []
+        for a in self._FIELDS:
+            if getattr(self, a) is not None:
+                fields.extend(_extract_fieldrefs(a, getattr(self, a), prefix))
+        return fields
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        for a in self._FIELDS:
+            self_v = getattr(self, a, None)
+            other_v = getattr(other, a, None)
+            if self_v != other_v:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def add(self, other):
+        new_props = {}
+        for a in self._FIELDS:
+            self_v = getattr(self, a, None)
+            other_v = getattr(other, a, None)
+            if isinstance(self_v, CellFormatComponent):
+                this_v = self_v.add(other_v)
+            elif other_v is not None:
+                this_v = other_v
+            else:
+                this_v = self_v
+            if this_v is not None:
+                new_props[a] = _extract_props(this_v)
+        return self.__class__.from_props(new_props)
+
+    __add__ = add
+
+    def intersection(self, other):
+        new_props = {}
+        for a in self._FIELDS:
+            self_v = getattr(self, a, None)
+            other_v = getattr(other, a, None)
+            this_v = None
+            if isinstance(self_v, CellFormatComponent):
+                this_v = self_v.intersection(other_v)
+            elif self_v == other_v:
+                this_v = self_v
+            if this_v is not None:
+                new_props[a] = _extract_props(this_v)
+        return self.__class__.from_props(new_props) if new_props else None
+
+    __and__ = intersection
+
+    def difference(self, other):
+        new_props = {}
+        for a in self._FIELDS:
+            self_v = getattr(self, a, None)
+            other_v = getattr(other, a, None)
+            this_v = None
+            if isinstance(self_v, CellFormatComponent):
+                this_v = self_v.difference(other_v)
+            elif other_v != self_v:
+                this_v = self_v
+            if this_v is not None:
+                new_props[a] = _extract_props(this_v)
+        return self.__class__.from_props(new_props) if new_props else None
+
+    __sub__ = difference
+
+
+class CellFormat(CellFormatComponent):
+    _FIELDS = (
+        'numberFormat', 'backgroundColor', 'borders', 'padding',
+        'horizontalAlignment', 'verticalAlignment', 'wrapStrategy',
+        'textDirection', 'textFormat', 'hyperlinkDisplayType', 'textRotation'
+    )
+
+    def __init__(self,
+                 numberFormat=None,
+                 backgroundColor=None,
+                 borders=None,
+                 padding=None,
+                 horizontalAlignment=None,
+                 verticalAlignment=None,
+                 wrapStrategy=None,
+                 textDirection=None,
+                 textFormat=None,
+                 hyperlinkDisplayType=None,
+                 textRotation=None
+                 ):
+        self.numberFormat = numberFormat
+        self.backgroundColor = backgroundColor
+        self.borders = borders
+        self.padding = padding
+        self.horizontalAlignment = _parse_string_enum('horizontalAlignment', horizontalAlignment,
+                                                      set(['LEFT', 'CENTER', 'RIGHT']))
+        self.verticalAlignment = _parse_string_enum('verticalAlignment', verticalAlignment,
+                                                    set(['TOP', 'MIDDLE', 'BOTTOM']))
+        self.wrapStrategy = _parse_string_enum('wrapStrategy', wrapStrategy,
+                                               set(['OVERFLOW_CELL', 'LEGACY_WRAP', 'CLIP', 'WRAP']))
+        self.textDirection = _parse_string_enum('textDirection', textDirection, set(['LEFT_TO_RIGHT', 'RIGHT_TO_LEFT']))
+        self.textFormat = textFormat
+        self.hyperlinkDisplayType = _parse_string_enum('hyperlinkDisplayType', hyperlinkDisplayType,
+                                                       set(['LINKED', 'PLAIN_TEXT']))
+        self.textRotation = textRotation
+
+
+class NumberFormat(CellFormatComponent):
+    _FIELDS = ('type', 'pattern')
+
+    TYPES = set(['TEXT', 'NUMBER', 'PERCENT', 'CURRENCY', 'DATE', 'TIME', 'DATE_TIME', 'SCIENTIFIC'])
+
+    def __init__(self, type, pattern=None):
+        if type.upper() not in TYPES:
+            raise ValueError("NumberFormat.type must be one of: %s" % TYPES)
+        self.type = type.upper()
+        self.pattern = pattern
+
+
+class Color(CellFormatComponent):
+    _FIELDS = ('red', 'green', 'blue', 'alpha')
+
+    def __init__(self, red=None, green=None, blue=None, alpha=None):
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.alpha = alpha
+
+
+class Borders(CellFormatComponent):
+    _FIELDS = ('top', 'bottom', 'left', 'right')
+
+    def __init__(self, top=None, bottom=None, left=None, right=None):
+        self.top = top
+        self.bottom = bottom
+        self.left = left
+        self.right = right
+
+
+class Border(CellFormatComponent):
+    _FIELDS = ('style', 'color')
+
+    STYLES = set(['DOTTED', 'DASHED', 'SOLID', 'SOLID_MEDIUM', 'SOLID_THICK', 'NONE', 'DOUBLE'])
+
+    def __init__(self, style, color):
+        if style.upper() not in STYLES:
+            raise ValueError("Border.style must be one of: %s" % STYLES)
+        self.style = style.upper()
+        self.color = color
+
+
+class Padding(CellFormatComponent):
+    _FIELDS = ('top', 'right', 'bottom', 'left')
+
+    def __init__(self, top=None, right=None, bottom=None, left=None):
+        self.top = top
+        self.right = right
+        self.bottom = bottom
+        self.left = left
+
+
+class TextFormat(CellFormatComponent):
+    _FIELDS = ('foregroundColor', 'fontFamily', 'fontSize', 'bold', 'italic', 'strikethrough', 'underline')
+
+    def __init__(self,
+                 foregroundColor=None,
+                 fontFamily=None,
+                 fontSize=None,
+                 bold=None,
+                 italic=None,
+                 strikethrough=None,
+                 underline=None
+                 ):
+        self.foregroundColor = foregroundColor
+        self.fontFamily = fontFamily
+        self.fontSize = fontSize
+        self.bold = bold
+        self.italic = italic
+        self.strikethrough = strikethrough
+        self.underline = underline
+
+
+class TextRotation(CellFormatComponent):
+    _FIELDS = ('angle', 'vertical')
+
+    def __init__(self, angle=None, vertical=None):
+        if len([expr for expr in (angle is not None, vertical is not None) if expr]) != 1:
+            raise ValueError("Either angle or vertical must be specified, not both or neither")
+        self.angle = angle
+        self.vertical = vertical
+
+
+# provide camelCase aliases for all component classes.
+
+_CLASSES = {}
+for _c in [obj for name, obj in locals().items() if isinstance(obj, type) and issubclass(obj, CellFormatComponent)]:
+    _k = _underlower(_c.__name__)
+    _CLASSES[_k] = _c
+    locals()[_k] = _c
+_CLASSES['foregroundColor'] = Color
+_CLASSES['backgroundColor'] = Color

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -348,12 +348,18 @@ class Worksheet(object):
     @property
     def frozen_row_count(self):
         """Number of frozen rows."""
-        return self._properties['gridProperties']['frozenRowCount']
+        try:
+            return self._properties['gridProperties']['frozenRowCount']
+        except KeyError:
+            return 0
 
     @property
     def frozen_col_count(self):
         """Number of frozen columns."""
-        return self._properties['gridProperties']['frozenColumnCount']
+        try:
+            return self._properties['gridProperties']['frozenColumnCount']
+        except KeyError:
+            return 0
 
     @property
     def hide_gridlines(self):

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -210,7 +210,8 @@ def fill_gaps(L, rows=None, cols=None):
 def cell_list_to_rect(cell_list):
     if not cell_list:
         return []
-
+    
+    cell_list.sort(key = lambda x: (x.row, x.col))
     rows = defaultdict(lambda: {})
 
     row_offset = cell_list[0].row


### PR DESCRIPTION
This may be more of an edge case situation, but for me, it is a common situation I run into while using update_cells to keep some business documents in sync with other systems.

This problem is most commonly cause by someone shifting cells in a worksheet.

I compiled a crude code sample which demonstrates this issue below. To take this a step further as a real world example: A sheet would get updated by external sources (as well as manually), with the tabs showing different views/analytics for different departments.

```python
credentials = get_credentials()
gc = gspread.authorize(credentials)

main_sheet = gc.open_by_key('sheet-id').worksheet('Main')
# main_sheet_headers = ["Reference Col C", "Reference Col D", "Reference Col A", "Reference Col B"]
main_sheet_data = main_sheet.get_all_values()
main_sheet_headers = []
for row in main_sheet_data[0]:
    main_sheet_headers.append(row)

update_sheet = gc.open_by_key('sheet-id').worksheet('Update Here')
# update_sheet_headers = ["Reference Col D", "Reference Col A", "Reference Col B", "Reference Col C"]
update_sheet_data = update_sheet.get_all_values()
update_sheet_headers = []
for row in update_sheet_data[0]:
    update_sheet_headers.append(row)

updated_data = {}

for row, col in enumerate(main_sheet_data):
    updated_data[row] = {
        'Reference Col A': '=Main!' + gspread.utils.rowcol_to_a1(row + 2, main_sheet_headers.index('Reference Col A') + 1),
        'Reference Col B': '=Main!' + gspread.utils.rowcol_to_a1(row + 2, main_sheet_headers.index('Reference Col B') + 1),
        'Reference Col C': '=Main!' + gspread.utils.rowcol_to_a1(row + 2, main_sheet_headers.index('Reference Col C') + 1),
        'Reference Col D': '=Main!' + gspread.utils.rowcol_to_a1(row + 2, main_sheet_headers.index('Reference Col D') + 1),
        }

updates = []
for row in updated_data:
    for col in updated_data[row]:
        updates.append(
            gspread.models.Cell(row + 2, update_sheet_headers.index(col) + 1, value = updated_data[row][col]))

print("Raw Cell list out of order")
for update in updates:
    print(update)

#  out data is out of order
#  <Cell R2C2 '=Main!C2'>
#  <Cell R2C3 '=Main!D2'>
#  <Cell R2C4 '=Main!A2'>
#  <Cell R2C1 '=Main!B2'>
#  This will cause not all updates to happen for update_cells
#  because of cell.row cell.col offsets in cell_list_to_rect
#  may cause cell col offset to be a negative

update_sheet.update_cells(updates, value_input_option = 'USER_ENTERED')
```

This issue arises due to the need to offset rows and columns in utils.py  cell_list_to_rect().

```python
row_offset = cell_list[0].row
col_offset = cell_list[0].col
```

Since it is using index 0, it is offsetting by the incorrect amount in this edge case. In cases where cell_list is constructed in the correct sequence, this is not an issue.

A workaround that I've used in the past would be something like this:

```python
updates = []
for row in updated_data:
    for header in update_sheet_headers:
        if header in updated_data[row]:
        # for col in updated_data[row]:
            updates.append(
                gspread.models.Cell(row + 2, amazon_data_headers.index(header) + 1, value = updated_data[row][header])
                )
```

Ideally, I would restructure this and recreate a Cells object which could be indexable.

Tweaking the function cell_list_to_rect() to sort cell_list by rows and columns prior to formatting to send to the Google API gives the most flexibility.

```python
def cell_list_to_rect(cell_list):
    if not cell_list:
        return []
    
    cell_list.sort(key = lambda x: (x.row, x.col))
    ...
```
![2018-08-06_22-12-19](https://user-images.githubusercontent.com/136438/43751009-108c8b12-99c9-11e8-8465-23604aa4987a.png)
![2018-08-06_21-54-34](https://user-images.githubusercontent.com/136438/43751010-10991882-99c9-11e8-97b0-3c3d40a337f5.png)