### PR TITLE
Fix update_cell on non rect cell list

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -216,8 +216,8 @@ def cell_list_to_rect(cell_list):
 
     rows = defaultdict(lambda: {})
 
-    row_offset = cell_list[0].row
-    col_offset = cell_list[0].col
+    row_offset = min(c.row for c in cell_list)
+    col_offset = min(c.col for c in cell_list)
 
     for cell in cell_list:
         row = rows.setdefault(int(cell.row) - row_offset, {})


### PR DESCRIPTION
This fix is for the case then list of cell passed to sheet-update_cell are not top-left conner of upate rect