### PR TITLE
Add with_link attribute when sharing / adding permissions

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -275,7 +275,8 @@ class Client(object):
         perm_type,
         role,
         notify=True,
-        email_message=None
+        email_message=None,
+        with_link=False
     ):
         """Creates a new permission for a file.
 
@@ -296,6 +297,9 @@ class Client(object):
         :type notify: str
         :param email_message: (optional) An email message to be sent if notify=True.
         :type email_message: str
+        
+        :param with_link: (optional) Whether the link is required for this permission to be active.
+        :type with_link: bool
 
         Examples::
 
@@ -325,6 +329,7 @@ class Client(object):
             'value': value,
             'type': perm_type,
             'role': role,
+            'withLink': with_link
         }
 
         params = {

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -340,7 +340,7 @@ class Spreadsheet(object):
 
         return self.batch_update(body)
 
-    def share(self, value, perm_type, role, notify=True, email_message=None):
+    def share(self, value, perm_type, role, notify=True, email_message=None, with_link=False):
         """Share the spreadsheet with other accounts.
 
         :param value: user or group e-mail address, domain name
@@ -357,6 +357,9 @@ class Spreadsheet(object):
         :type notify: str
         :param email_message: (optional) The email to be sent if notify=True
         :type email_message: str
+        
+        :param with_link: (optional) Whether the link is required for this permission
+        :type with_link: bool
 
         Example::
 
@@ -373,7 +376,8 @@ class Spreadsheet(object):
             perm_type=perm_type,
             role=role,
             notify=notify,
-            email_message=email_message
+            email_message=email_message,
+            with_link=with_link
         )
 
     def list_permissions(self):


### PR DESCRIPTION
The with_link attribute (https://developers.google.com/drive/api/v2/reference/permissions) (API doc) 
This PR:
- Adds a `with_link` kwarg to `gspread.client.insert_permission`
- Adds a `with_link` kwarg to `gspread.models.Spreadsheet.share`
- By default, `with_link` is set to false (so publicly accessible spreadsheets are publicly findable), but when it is sent to true, then publicly accessible spreadsheets are only accessible for users with the link.