### PR TITLE
A method to copy spreadsheets

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -214,6 +214,48 @@ class Client(object):
         spreadsheet_id = r.json()['id']
         return self.open_by_key(spreadsheet_id)
 
+    def copy(self, key, title=None):
+        """Copies a spreadsheet.
+
+        :param key: A key of a spreadsheet to copy.
+        :type title: str
+
+        :param title: A title of a new spreadsheet.
+        :type title: str
+
+        :returns: a :class:`~gspread.models.Spreadsheet` instance.
+
+        .. note::
+
+           In order to use this method, you need to add
+           ``https://www.googleapis.com/auth/drive`` to your oAuth scope.
+
+           Example::
+
+              scope = [
+                  'https://spreadsheets.google.com/feeds',
+                  'https://www.googleapis.com/auth/drive'
+              ]
+
+           Otherwise you will get an ``Insufficient Permission`` error
+           when you try to copy a spreadsheet.
+
+        """
+        if title is None:
+            original = self.open_by_key(key)
+            title = "{} (copy)".format(original.title)
+        payload = {
+            'title': title,
+            'mimeType': 'application/vnd.google-apps.spreadsheet'
+        }
+        r = self.request(
+            'post',
+            "https://www.googleapis.com/drive/v2/files/" + key + '/copy',
+            json=payload
+        )
+        spreadsheet_id = r.json()['id']
+        return self.open_by_key(spreadsheet_id)
+
     def del_spreadsheet(self, file_id):
         """Deletes a spreadsheet.
 

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -214,10 +214,10 @@ class Client(object):
         spreadsheet_id = r.json()['id']
         return self.open_by_key(spreadsheet_id)
 
-    def copy(self, key, title=None, copy_permissions=False):
+    def copy(self, file_id, title=None, copy_permissions=False):
         """Copies a spreadsheet.
 
-        :param key: A key of a spreadsheet to copy.
+        :param file_id: A key of a spreadsheet to copy.
         :type title: str
 
         :param title: (optional) A title for the new spreadsheet.
@@ -246,9 +246,10 @@ class Client(object):
            when you try to copy a spreadsheet.
 
         """
-        if title is None:
-            original = self.open_by_key(key)
-            title = 'Copy of {}'.format(original.title)
+        url = '{0}/{1}/copy'.format(
+            DRIVE_FILES_API_V2_URL,
+            file_id
+        )
 
         payload = {
             'title': title,
@@ -256,7 +257,7 @@ class Client(object):
         }
         r = self.request(
             'post',
-            'https://www.googleapis.com/drive/v2/files/' + key + '/copy',
+            url,
             json=payload
         )
         spreadsheet_id = r.json()['id']
@@ -264,8 +265,7 @@ class Client(object):
         new_spreadsheet = self.open_by_key(spreadsheet_id)
 
         if copy_permissions:
-            if 'original' not in locals():
-                original = self.open_by_key(key)
+            original = self.open_by_key(file_id)
 
             permissions = original.list_permissions()
             for p in permissions:

--- a/tests/test.py
+++ b/tests/test.py
@@ -201,6 +201,15 @@ class ClientTest(GspreadTest):
         new_spreadsheet = self.gc.create(title)
         self.assertTrue(isinstance(new_spreadsheet, gspread.models.Spreadsheet))
 
+    def test_copy(self):
+        original_spreadsheet = self.gc.create("Original")
+        spreadsheet_copy = self.gc.copy(original_spreadsheet.id)
+        self.assertTrue(isinstance(spreadsheet_copy, gspread.models.Spreadsheet))
+
+        original_metadata = original_spreadsheet.fetch_sheet_metadata()
+        copy_metadata = spreadsheet_copy.fetch_sheet_metadata()
+        self.assertEqual(original_metadata['sheets'], copy_metadata['sheets'])
+
     def test_import_csv(self):
         title = 'TestImportSpreadsheet'
         new_spreadsheet = self.gc.create(title)


### PR DESCRIPTION
Adds a method to copy spreadsheets, as requested in Issue #158. This is the same functionality as Pull Request #459 but reworked much like @burnash suggested.

Usage example:
```
spreadsheet_copy = client.copy(key, title="Copied Sheet", copy_permissions=True)
```

A title for the new spreadsheet can be specified optionally; the default is "Copy of <original_title>".

`copy_permissions=True` will share the new spreadsheet with everyone who had access to the original. This can be slow for sheets that are shared with many users and is disabled by default.
