### PR TITLE
Fixed IndexError in get_all_records

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -626,6 +626,11 @@ class Worksheet(object):
         idx = head - 1
 
         data = self.get_all_values()
+
+        # Return an empty list if the sheet doesn't have enough rows
+        if len(data) < idx:
+            return []
+
         keys = data[idx]
         values = [
             numericise_all(


### PR DESCRIPTION
Added data length checking to prevent `IndexError` in `.get_all_records()` method of `Worksheet` class. This is a small fix for the issue #629.