### PR TITLE
Exception message

### DIFF
--- a/gspread/exceptions.py
+++ b/gspread/exceptions.py
@@ -45,6 +45,6 @@ class APIError(GSpreadException):
     def _text_from_detail(self, response):
         try:
             errors = response.json()
-            return errors['detail']
+            return errors['error']
         except (AttributeError, KeyError, ValueError):
             return None

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,6 +7,7 @@ import unittest
 import itertools
 from collections import namedtuple
 
+from gspread.exceptions import APIError
 from oauth2client.service_account import ServiceAccountCredentials
 
 from betamax import Betamax
@@ -229,6 +230,15 @@ class ClientTest(GspreadTest):
         self.assertEqual(sh.sheet1.get_all_values(), rows)
 
         self.gc.del_spreadsheet(new_spreadsheet.id)
+
+    def test_access_non_existing_spreadsheet(self):
+        wks = self.gc.open_by_key('test')
+        with self.assertRaises(APIError) as error:
+            wks.worksheets()
+        self.assertEqual(error.exception.args[0]['code'], 404)
+        self.assertEqual(error.exception.args[0]['message'], 'Requested entity was not found.')
+        self.assertEqual(error.exception.args[0]['status'], 'NOT_FOUND')
+
 
 
 class SpreadsheetTest(GspreadTest):


### PR DESCRIPTION
I have noticed that when an error occurs that user does not receive user friendly message. Before my change user has received an json response in args as string.

`error.exception.args[0]` has value of 
```json
'{
  "error": {
    "code": 404,
    "message": "Requested entity was not found.",
    "status": "NOT_FOUND"
  }
}
'
```

after my change `args` has populated with dict with values from json.
```python
self.assertEqual(error.exception.args[0]['code'], 404)
self.assertEqual(error.exception.args[0]['message'], 'Requested entity was not found.')
self.assertEqual(error.exception.args[0]['status'], 'NOT_FOUND')
```

Thanks for great lib. :+1: 