### PR TITLE
Stop keyerror on permissions list comprehension

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -405,7 +405,7 @@ class Spreadsheet(object):
 
         filtered_id_list = [
             p['id'] for p in permission_list
-            if p[key] == value and (p['role'] == role or role == 'any')
+            if p.get(key) == value and (p['role'] == role or role == 'any')
         ]
 
         for permission_id in filtered_id_list:


### PR DESCRIPTION
If there is an item in a worksheet's permissions list that does not have an `emailAddress` attribute, a `KeyError` will be raised in this listcomp. This issue can be solved by using dict.get() notation that will return `None` if the emailAddress key does not exist.