### PR TITLE
Clarify supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,13 @@ setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     url='https://github.com/burnash/gspread',
     keywords=['spreadsheets', 'google-spreadsheets'],
     install_requires=['requests>=2.2.1'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
* `python_requires` helps pip install the right version for the running Python
* Trove classifiers makes it clear on PyPI which versions are supported