### PR TITLE
Fixed offset computing in cell_list_to_rect

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -230,8 +230,8 @@ def cell_list_to_rect(cell_list):
 
     rows = defaultdict(lambda: {})
 
-    row_offset = cell_list[0].row
-    col_offset = cell_list[0].col
+    row_offset = min(cell.row for cell in cell_list)
+    col_offset = min(cell.col for cell in cell_list)
 
     for cell in cell_list:
         row = rows.setdefault(int(cell.row) - row_offset, {})


### PR DESCRIPTION
First thanks for the great library!

The input for `cell_list_to_rect` is assumed to be sorted, as it uses the first cell in the given list for the offset. If it is not, there will be cell updates with negative indices, that will be just omitted. 
