### PR TITLE
Added add_rows method to simplify the procedure of adding multiple rows

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -896,7 +896,7 @@ class Worksheet(object):
         """Adds rows to the worksheet and populates it with values.
         Widens the worksheet if there are more values than columns.
 
-        :param values: Values for new rows.
+        :param values: Values for new rows. Values must be a list of lists.
         :param value_input_option: (optional) Determines how input data should
                                     be interpreted. See `ValueInputOption`_ in
                                     the Sheets API.

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -892,7 +892,7 @@ class Worksheet(object):
 
         return self.spreadsheet.values_append(self.title, params, body)
     
-        def append_rows(self, values, value_input_option='RAW'):
+    def append_rows(self, values, value_input_option='RAW'):
         """Adds rows to the worksheet and populates it with values.
         Widens the worksheet if there are more values than columns.
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -893,10 +893,10 @@ class Worksheet(object):
         return self.spreadsheet.values_append(self.title, params, body)
     
         def append_rows(self, values, value_input_option='RAW'):
-        """Adds a row to the worksheet and populates it with values.
+        """Adds rows to the worksheet and populates it with values.
         Widens the worksheet if there are more values than columns.
 
-        :param values: List of values for the new row.
+        :param values: Values for new rows.
         :param value_input_option: (optional) Determines how input data should
                                     be interpreted. See `ValueInputOption`_ in
                                     the Sheets API.

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -891,6 +891,29 @@ class Worksheet(object):
         }
 
         return self.spreadsheet.values_append(self.title, params, body)
+    
+        def append_rows(self, values, value_input_option='RAW'):
+        """Adds a row to the worksheet and populates it with values.
+        Widens the worksheet if there are more values than columns.
+
+        :param values: List of values for the new row.
+        :param value_input_option: (optional) Determines how input data should
+                                    be interpreted. See `ValueInputOption`_ in
+                                    the Sheets API.
+        :type value_input_option: str
+
+        .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
+
+        """
+        params = {
+            'valueInputOption': value_input_option
+        }
+
+        body = {
+            'values': values
+        }
+
+        return self.spreadsheet.values_append(self.title, params, body)
 
     def insert_row(
         self,


### PR DESCRIPTION
In order to make the process of adding multiple rows to a spreadsheet easier, I've added an add_rows method that allows the user to add multiple rows at once, thus decreasing execution time (less API calls) and overcoming the API write limit.