### PR TITLE
Set default argument to add_worksheet method

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -242,7 +242,7 @@ class Spreadsheet(object):
         except (StopIteration, KeyError):
             raise WorksheetNotFound(title)
 
-    def add_worksheet(self, title, rows, cols):
+    def add_worksheet(self, title, rows=1000, cols=26):
         """Adds a new worksheet to a spreadsheet.
 
         :param title: A title of a new worksheet.


### PR DESCRIPTION
First thanks for the great library!

I want to set default argument to add_worksheet method.
We execute `gc.create('A new spreadsheet')` , processing succeeds and new spreadsheet have 1,000 rows and 26 columns.
But, we execute `spreadsheet.add_worksheet('A new worksheet')`,  an error ( `TypeError: add_worksheet() missing 2 required positional arguments: 'rows' and 'cols'` ) occurs. We have to set argument `rows` and `columns` using add_worksheet method.

I think most gspread library's users want to use add_worksheet method more simply.
What are your thoughts on that?