### PR TITLE
Add more parameters to `Worksheet.append_row()`

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -891,28 +891,54 @@ class Worksheet(object):
         """
         self.resize(cols=self.col_count + cols)
 
-    def append_row(self, values, value_input_option='RAW'):
+    def append_row(
+        self,
+        values,
+        value_input_option='RAW',
+        insert_data_option=None,
+        table_range=None
+    ):
         """Adds a row to the worksheet and populates it with values.
         Widens the worksheet if there are more values than columns.
 
         :param values: List of values for the new row.
-        :param value_input_option: (optional) Determines how input data should
-                                    be interpreted. See `ValueInputOption`_ in
-                                    the Sheets API.
+        :param value_input_option: (optional) Determines how the input data
+                                    should be interpreted. See
+                                    `ValueInputOption`_ in the Sheets API
+                                    reference.
         :type value_input_option: str
+        :param insert_data_option: (optional) Determines how the input data
+                                    should be inserted. See
+                                    `InsertDataOption`_ in the Sheets API
+                                    reference.
+        :type insert_data_option: str
+        :param table_range: (optional) The A1 notation of a range to search for
+                             a logical table of data. Values are appended after
+                             the last row of the table.
+                             Examples: `A1` or `B2:D4`
+        :type table_range: str
 
         .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
+        .. _InsertDataOption: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append#InsertDataOption
 
         """
+
+        range_label = (
+            '%s!%s' % (self.title, table_range)
+            if table_range
+            else self.title
+        )
+
         params = {
-            'valueInputOption': value_input_option
+            'valueInputOption': value_input_option,
+            'insertDataOption': insert_data_option
         }
 
         body = {
             'values': [values]
         }
 
-        return self.spreadsheet.values_append(self.title, params, body)
+        return self.spreadsheet.values_append(range_label, params, body)
 
     def insert_row(
         self,

--- a/tests/cassettes/WorksheetTest.test_append_row_with_empty_value.json
+++ b/tests/cassettes/WorksheetTest.test_append_row_with_empty_value.json
@@ -1,0 +1,1370 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-02-17T13:20:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value 1\", \"\", \"test_append_row_with_empty_value 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "94"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n  \"tableRange\": \"wksht_test!C1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n    \"updatedRange\": \"wksht_test!C2:E2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:13 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+          "tableRange": "wksht_test!C1",
+          "updates": {
+            "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!C2:E2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"\",\n      \"\",\n      \"test_append_row_with_empty_value 1\",\n      \"\",\n      \"test_append_row_with_empty_value 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:13 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "",
+              "",
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value 1\", \"\", \"test_append_row_with_empty_value 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "94"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A1:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n  \"tableRange\": \"wksht_test!A1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n    \"updatedRange\": \"wksht_test!A2:C2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:13 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+          "tableRange": "wksht_test!A1",
+          "updates": {
+            "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A2:C2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A1:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A3%3A3?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A3:T3\",\n  \"majorDimension\": \"ROWS\"\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:14 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A3:T3"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A3%3A3?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A1:T20\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"test_append_row_with_empty_value 1\",\n      \"\",\n      \"test_append_row_with_empty_value 3\"\n    ],\n    [\n      \"test_append_row_with_empty_value 1\",\n      \"\",\n      \"test_append_row_with_empty_value 3\",\n      \"\",\n      \"test_append_row_with_empty_value 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:14 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A1:T20",
+          "values": [
+            [
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ],
+            [
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 540405102}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "55"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 540405102
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:15 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:21:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value 1\", \"\", \"test_append_row_with_empty_value 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "94"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ\",\n  \"tableRange\": \"wksht_test!C1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ\",\n    \"updatedRange\": \"wksht_test!C2:E2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:21:53 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ",
+          "tableRange": "wksht_test!C1",
+          "updates": {
+            "spreadsheetId": "1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!C2:E2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:21:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"\",\n      \"\",\n      \"test_append_row_with_empty_value 1\",\n      \"\",\n      \"test_append_row_with_empty_value 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:21:54 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "",
+              "",
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:21:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 801139168}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "55"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 801139168
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:21:54 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1UE0ionzsEYwE9zw_KIc155uF9Nn116XSWMZ-x025xHQ:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%27application%2Fvnd.google-apps.spreadsheet%27&pageSize=1000&supportsTeamDrives=True&includeTeamDriveItems=True"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n \"kind\": \"drive#fileList\",\n \"incompleteSearch\": false,\n \"files\": [\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n   \"name\": \"Test WorksheetTest\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"12NoVuKnh9Qp9hChg_Yomvado8VBWG9UD-eCZi95ILqQ\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1gioqW7yDRv7uPlKW4NX42K4BW6yaEFSdUAsmWDDf2U4\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1tvjenePAidZhVcq1jJb9UN_o5v5rlDJcWJjlyDUBLWc\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1nJn7nBEmXs017kflLoafLDwFVI3fygIBK6zAtS-Na4w\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1qamf_EGUk4g7k-5mP1MozCHIF5QirDjkWnqkf1h-Wj4\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1jalcKSMTUuIKu4OoZl3VELQ3hqlp9dRt14NJsAHxeoc\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"13sDJuPOxljHHJajjPFCo9VEXbkLYy_MoszcgXAfvJDU\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1RilYJj_n14OQTaYeNbPeTf1bZirrGhcQmvjssxLzAv0\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"10wJuJK2KcOw6Vk_vr3y-xELcOPCPAyzGkLXyIMJ2dbM\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1p38FeYjqYrXrOLAo9vLvVOkGHchJ5i_k4V3Zv386tGo\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1tCWhNZz4-6Gvt2jiWpRXxenTYlJWA1eicWdW1iTWLtQ\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1cdVLkIOT_SrLw8NWfk0YUaGIRngc2T0S_s5w6j3S-qc\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1nwadmNfz141TVp4BoMPABZreUh9OZOfXDAcK4JmACtA\",\n   \"name\": \"test-notation\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1rjAR01GQqW4fqoiIzUrycjfKvOKuWIC5YY_7WWT8Lv4\",\n   \"name\": \"test\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"19BlScYdZNWd-L5gITpjkZUpOajl4LFJkwvzeibI2JJs\",\n   \"name\": \"Test WorksheetTest\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1QbM0eCGUkBcIvQ-HTZphmibcXTeYQIRdWo6I24lH888\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1Y6dosp9YgT0U2Xad8LkPejqdH9J7zOqT71XVCGH9g_4\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"131Id-sW4Bn1fEVrVQXdZw4AUz42h_1fjOuU2pX-wW9o\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1q6K67hv3DcK1ZxK2A45W9ux5TKz2KWkl9v1Y5YElTsE\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1Ms0B0FSxVpz8mIK3vDdHcifo9SGNJjoKMLEwKAao5W0\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1aaGximNlN3VMfF5Ug2pq9xwXNdhHCTFWqyqz1H7mP0s\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1EuhIX0HF6wCbL0i3Ve4_lipw21nUiQ1O3zVpcYJsa_8\",\n   \"name\": \"Copy of test-sheet2\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1r9_MeKWEYHWChvqJUbTkzkwqk25XWe-a9SEYPxmKshc\",\n   \"name\": \"test-sheet2\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1thlSGXDKr9Q5VfjN_k7K3X6dy4p-tfEKYuVfvfFlKE4\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1eG50XFrh2Fvi21Szd9VIK4RUutfok24QD9w53FpD4og\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1cxkCYcbqbGlaqy02yX25lCr7HhZaTV-KknSqB8Cv5NM\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1qwVtOrQJc-_qZTklWmWQpgvRBXEU8-L-2mSDzfSvzb0\",\n   \"name\": \"test-csv-import\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1eUT6ds5Fe9EVatZ5qEWrlh80tEv6srIfYeTHy5KVBlc\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1736oDu6ubcC59mgjctDDqmTet3zh7STBu9O_ltp4cHw\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  }\n ]\n}\n"
+        },
+        "headers": {
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private, max-age=0, must-revalidate, no-transform"
+          ],
+          "Content-Length": [
+            "5381"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:31 GMT"
+          ],
+          "Expires": [
+            "Mon, 17 Feb 2020 18:13:31 GMT"
+          ],
+          "Server": [
+            "GSE"
+          ],
+          "Vary": [
+            "Origin",
+            "X-Origin"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "json_body": {
+          "files": [
+            {
+              "id": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test WorksheetTest"
+            },
+            {
+              "id": "12NoVuKnh9Qp9hChg_Yomvado8VBWG9UD-eCZi95ILqQ",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1gioqW7yDRv7uPlKW4NX42K4BW6yaEFSdUAsmWDDf2U4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1tvjenePAidZhVcq1jJb9UN_o5v5rlDJcWJjlyDUBLWc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1nJn7nBEmXs017kflLoafLDwFVI3fygIBK6zAtS-Na4w",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1qamf_EGUk4g7k-5mP1MozCHIF5QirDjkWnqkf1h-Wj4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1jalcKSMTUuIKu4OoZl3VELQ3hqlp9dRt14NJsAHxeoc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "13sDJuPOxljHHJajjPFCo9VEXbkLYy_MoszcgXAfvJDU",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1RilYJj_n14OQTaYeNbPeTf1bZirrGhcQmvjssxLzAv0",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "10wJuJK2KcOw6Vk_vr3y-xELcOPCPAyzGkLXyIMJ2dbM",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1p38FeYjqYrXrOLAo9vLvVOkGHchJ5i_k4V3Zv386tGo",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1tCWhNZz4-6Gvt2jiWpRXxenTYlJWA1eicWdW1iTWLtQ",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1cdVLkIOT_SrLw8NWfk0YUaGIRngc2T0S_s5w6j3S-qc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1nwadmNfz141TVp4BoMPABZreUh9OZOfXDAcK4JmACtA",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test-notation"
+            },
+            {
+              "id": "1rjAR01GQqW4fqoiIzUrycjfKvOKuWIC5YY_7WWT8Lv4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test"
+            },
+            {
+              "id": "19BlScYdZNWd-L5gITpjkZUpOajl4LFJkwvzeibI2JJs",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test WorksheetTest"
+            },
+            {
+              "id": "1QbM0eCGUkBcIvQ-HTZphmibcXTeYQIRdWo6I24lH888",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1Y6dosp9YgT0U2Xad8LkPejqdH9J7zOqT71XVCGH9g_4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "131Id-sW4Bn1fEVrVQXdZw4AUz42h_1fjOuU2pX-wW9o",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1q6K67hv3DcK1ZxK2A45W9ux5TKz2KWkl9v1Y5YElTsE",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1Ms0B0FSxVpz8mIK3vDdHcifo9SGNJjoKMLEwKAao5W0",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1aaGximNlN3VMfF5Ug2pq9xwXNdhHCTFWqyqz1H7mP0s",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1EuhIX0HF6wCbL0i3Ve4_lipw21nUiQ1O3zVpcYJsa_8",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of test-sheet2"
+            },
+            {
+              "id": "1r9_MeKWEYHWChvqJUbTkzkwqk25XWe-a9SEYPxmKshc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test-sheet2"
+            },
+            {
+              "id": "1thlSGXDKr9Q5VfjN_k7K3X6dy4p-tfEKYuVfvfFlKE4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1eG50XFrh2Fvi21Szd9VIK4RUutfok24QD9w53FpD4og",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1cxkCYcbqbGlaqy02yX25lCr7HhZaTV-KknSqB8Cv5NM",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1qwVtOrQJc-_qZTklWmWQpgvRBXEU8-L-2mSDzfSvzb0",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test-csv-import"
+            },
+            {
+              "id": "1eUT6ds5Fe9EVatZ5qEWrlh80tEv6srIfYeTHy5KVBlc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1736oDu6ubcC59mgjctDDqmTet3zh7STBu9O_ltp4cHw",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            }
+          ],
+          "incompleteSearch": false,
+          "kind": "drive#fileList"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%27application%2Fvnd.google-apps.spreadsheet%27&pageSize=1000&supportsTeamDrives=True&includeTeamDriveItems=True"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value 1\", \"\", \"test_append_row_with_empty_value 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "94"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n  \"tableRange\": \"wksht_test!C1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n    \"updatedRange\": \"wksht_test!C2:E2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:32 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+          "tableRange": "wksht_test!C1",
+          "updates": {
+            "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!C2:E2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"\",\n      \"\",\n      \"test_append_row_with_empty_value 1\",\n      \"\",\n      \"test_append_row_with_empty_value 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:32 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "",
+              "",
+              "test_append_row_with_empty_value 1",
+              "",
+              "test_append_row_with_empty_value 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 1581607143}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "56"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 1581607143
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:33 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E:batchUpdate"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/cassettes/WorksheetTest.test_append_row_with_empty_value_and_table_range.json
+++ b/tests/cassettes/WorksheetTest.test_append_row_with_empty_value_and_table_range.json
@@ -1,0 +1,2141 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-02-17T12:10:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo\",\n  \"updates\": {\n    \"spreadsheetId\": \"1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo\",\n    \"updatedRange\": \"wksht_test!A1:C1\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:10:32 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo",
+          "updates": {
+            "spreadsheetId": "1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A1:C1",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:10:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo/values/wksht_test%21A1:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo\",\n  \"tableRange\": \"wksht_test!A1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo\",\n    \"updatedRange\": \"wksht_test!A2:C2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:10:33 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo",
+          "tableRange": "wksht_test!A1",
+          "updates": {
+            "spreadsheetId": "1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A2:C2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo/values/wksht_test%21A1:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:10:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"test_append_row_with_empty_value_and_table_range 1\",\n      \"\",\n      \"test_append_row_with_empty_value_and_table_range 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:10:33 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:10:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 1334011119}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "56"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 1334011119
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:10:33 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1p3lE9-WduJeFTvQ9y9ZjP4bxiVX7UhEJ1u3x_ElMJPo:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:10:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE\",\n  \"updates\": {\n    \"spreadsheetId\": \"1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE\",\n    \"updatedRange\": \"wksht_test!A1:C1\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:10:59 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE",
+          "updates": {
+            "spreadsheetId": "1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A1:C1",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:11:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE/values/wksht_test%21A1:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE\",\n  \"tableRange\": \"wksht_test!A1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE\",\n    \"updatedRange\": \"wksht_test!A2:C2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:10:59 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE",
+          "tableRange": "wksht_test!A1",
+          "updates": {
+            "spreadsheetId": "1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A2:C2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE/values/wksht_test%21A1:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:11:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"test_append_row_with_empty_value_and_table_range 1\",\n      \"\",\n      \"test_append_row_with_empty_value_and_table_range 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:11:00 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T12:11:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 277410034}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "55"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 277410034
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 12:11:00 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1uUt4BEguP-0H15f4OXfDP8eC8TtiQYo4VKiSABWdWzE:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:17:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8\",\n  \"updates\": {\n    \"spreadsheetId\": \"1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8\",\n    \"updatedRange\": \"wksht_test!A1:C1\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:17:53 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8",
+          "updates": {
+            "spreadsheetId": "1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A1:C1",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:17:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8/values/wksht_test%21A1:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8\",\n  \"tableRange\": \"wksht_test!A1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8\",\n    \"updatedRange\": \"wksht_test!A2:C2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:17:53 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8",
+          "tableRange": "wksht_test!A1",
+          "updates": {
+            "spreadsheetId": "1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A2:C2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8/values/wksht_test%21A1:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:17:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"test_append_row_with_empty_value_and_table_range 1\",\n      \"\",\n      \"test_append_row_with_empty_value_and_table_range 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:17:54 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:17:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 674831186}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "55"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 674831186
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:17:54 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1yuf8y-sAXkyDoB3z_8zrjZpYhQzt0Hp2YHSBfPhZ5Y8:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n  \"updates\": {\n    \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n    \"updatedRange\": \"wksht_test!A1:C1\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:16 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+          "updates": {
+            "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A1:C1",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A1:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n  \"tableRange\": \"wksht_test!A1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n    \"updatedRange\": \"wksht_test!A2:C2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:16 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+          "tableRange": "wksht_test!A1",
+          "updates": {
+            "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A2:C2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A1:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"test_append_row_with_empty_value_and_table_range 1\",\n      \"\",\n      \"test_append_row_with_empty_value_and_table_range 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:17 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T13:20:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 2100562720}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "56"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 2100562720
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 13:20:17 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1H673Ixo9B_nyG65jIzLIAo1w_2sO6vh0PY5kFsfDG_4:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%27application%2Fvnd.google-apps.spreadsheet%27&pageSize=1000&supportsTeamDrives=True&includeTeamDriveItems=True"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n \"kind\": \"drive#fileList\",\n \"incompleteSearch\": false,\n \"files\": [\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n   \"name\": \"Test WorksheetTest\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"12NoVuKnh9Qp9hChg_Yomvado8VBWG9UD-eCZi95ILqQ\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1gioqW7yDRv7uPlKW4NX42K4BW6yaEFSdUAsmWDDf2U4\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1tvjenePAidZhVcq1jJb9UN_o5v5rlDJcWJjlyDUBLWc\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1nJn7nBEmXs017kflLoafLDwFVI3fygIBK6zAtS-Na4w\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1qamf_EGUk4g7k-5mP1MozCHIF5QirDjkWnqkf1h-Wj4\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1jalcKSMTUuIKu4OoZl3VELQ3hqlp9dRt14NJsAHxeoc\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"13sDJuPOxljHHJajjPFCo9VEXbkLYy_MoszcgXAfvJDU\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1RilYJj_n14OQTaYeNbPeTf1bZirrGhcQmvjssxLzAv0\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"10wJuJK2KcOw6Vk_vr3y-xELcOPCPAyzGkLXyIMJ2dbM\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1p38FeYjqYrXrOLAo9vLvVOkGHchJ5i_k4V3Zv386tGo\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1tCWhNZz4-6Gvt2jiWpRXxenTYlJWA1eicWdW1iTWLtQ\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1cdVLkIOT_SrLw8NWfk0YUaGIRngc2T0S_s5w6j3S-qc\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1nwadmNfz141TVp4BoMPABZreUh9OZOfXDAcK4JmACtA\",\n   \"name\": \"test-notation\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1rjAR01GQqW4fqoiIzUrycjfKvOKuWIC5YY_7WWT8Lv4\",\n   \"name\": \"test\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"19BlScYdZNWd-L5gITpjkZUpOajl4LFJkwvzeibI2JJs\",\n   \"name\": \"Test WorksheetTest\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1QbM0eCGUkBcIvQ-HTZphmibcXTeYQIRdWo6I24lH888\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1Y6dosp9YgT0U2Xad8LkPejqdH9J7zOqT71XVCGH9g_4\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"131Id-sW4Bn1fEVrVQXdZw4AUz42h_1fjOuU2pX-wW9o\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1q6K67hv3DcK1ZxK2A45W9ux5TKz2KWkl9v1Y5YElTsE\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1Ms0B0FSxVpz8mIK3vDdHcifo9SGNJjoKMLEwKAao5W0\",\n   \"name\": \"Copy of Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1aaGximNlN3VMfF5Ug2pq9xwXNdhHCTFWqyqz1H7mP0s\",\n   \"name\": \"Original\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1EuhIX0HF6wCbL0i3Ve4_lipw21nUiQ1O3zVpcYJsa_8\",\n   \"name\": \"Copy of test-sheet2\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1r9_MeKWEYHWChvqJUbTkzkwqk25XWe-a9SEYPxmKshc\",\n   \"name\": \"test-sheet2\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1thlSGXDKr9Q5VfjN_k7K3X6dy4p-tfEKYuVfvfFlKE4\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1eG50XFrh2Fvi21Szd9VIK4RUutfok24QD9w53FpD4og\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1cxkCYcbqbGlaqy02yX25lCr7HhZaTV-KknSqB8Cv5NM\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1qwVtOrQJc-_qZTklWmWQpgvRBXEU8-L-2mSDzfSvzb0\",\n   \"name\": \"test-csv-import\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1eUT6ds5Fe9EVatZ5qEWrlh80tEv6srIfYeTHy5KVBlc\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  },\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1736oDu6ubcC59mgjctDDqmTet3zh7STBu9O_ltp4cHw\",\n   \"name\": \"Test Spreadsheet\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  }\n ]\n}\n"
+        },
+        "headers": {
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private, max-age=0, must-revalidate, no-transform"
+          ],
+          "Content-Length": [
+            "5381"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:33 GMT"
+          ],
+          "Expires": [
+            "Mon, 17 Feb 2020 18:13:33 GMT"
+          ],
+          "Server": [
+            "GSE"
+          ],
+          "Vary": [
+            "Origin",
+            "X-Origin"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "json_body": {
+          "files": [
+            {
+              "id": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test WorksheetTest"
+            },
+            {
+              "id": "12NoVuKnh9Qp9hChg_Yomvado8VBWG9UD-eCZi95ILqQ",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1gioqW7yDRv7uPlKW4NX42K4BW6yaEFSdUAsmWDDf2U4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1tvjenePAidZhVcq1jJb9UN_o5v5rlDJcWJjlyDUBLWc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1nJn7nBEmXs017kflLoafLDwFVI3fygIBK6zAtS-Na4w",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1qamf_EGUk4g7k-5mP1MozCHIF5QirDjkWnqkf1h-Wj4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1jalcKSMTUuIKu4OoZl3VELQ3hqlp9dRt14NJsAHxeoc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "13sDJuPOxljHHJajjPFCo9VEXbkLYy_MoszcgXAfvJDU",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1RilYJj_n14OQTaYeNbPeTf1bZirrGhcQmvjssxLzAv0",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "10wJuJK2KcOw6Vk_vr3y-xELcOPCPAyzGkLXyIMJ2dbM",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1p38FeYjqYrXrOLAo9vLvVOkGHchJ5i_k4V3Zv386tGo",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1tCWhNZz4-6Gvt2jiWpRXxenTYlJWA1eicWdW1iTWLtQ",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1cdVLkIOT_SrLw8NWfk0YUaGIRngc2T0S_s5w6j3S-qc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1nwadmNfz141TVp4BoMPABZreUh9OZOfXDAcK4JmACtA",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test-notation"
+            },
+            {
+              "id": "1rjAR01GQqW4fqoiIzUrycjfKvOKuWIC5YY_7WWT8Lv4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test"
+            },
+            {
+              "id": "19BlScYdZNWd-L5gITpjkZUpOajl4LFJkwvzeibI2JJs",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test WorksheetTest"
+            },
+            {
+              "id": "1QbM0eCGUkBcIvQ-HTZphmibcXTeYQIRdWo6I24lH888",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1Y6dosp9YgT0U2Xad8LkPejqdH9J7zOqT71XVCGH9g_4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "131Id-sW4Bn1fEVrVQXdZw4AUz42h_1fjOuU2pX-wW9o",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1q6K67hv3DcK1ZxK2A45W9ux5TKz2KWkl9v1Y5YElTsE",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1Ms0B0FSxVpz8mIK3vDdHcifo9SGNJjoKMLEwKAao5W0",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of Original"
+            },
+            {
+              "id": "1aaGximNlN3VMfF5Ug2pq9xwXNdhHCTFWqyqz1H7mP0s",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Original"
+            },
+            {
+              "id": "1EuhIX0HF6wCbL0i3Ve4_lipw21nUiQ1O3zVpcYJsa_8",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Copy of test-sheet2"
+            },
+            {
+              "id": "1r9_MeKWEYHWChvqJUbTkzkwqk25XWe-a9SEYPxmKshc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test-sheet2"
+            },
+            {
+              "id": "1thlSGXDKr9Q5VfjN_k7K3X6dy4p-tfEKYuVfvfFlKE4",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1eG50XFrh2Fvi21Szd9VIK4RUutfok24QD9w53FpD4og",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1cxkCYcbqbGlaqy02yX25lCr7HhZaTV-KknSqB8Cv5NM",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1qwVtOrQJc-_qZTklWmWQpgvRBXEU8-L-2mSDzfSvzb0",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "test-csv-import"
+            },
+            {
+              "id": "1eUT6ds5Fe9EVatZ5qEWrlh80tEv6srIfYeTHy5KVBlc",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            },
+            {
+              "id": "1736oDu6ubcC59mgjctDDqmTet3zh7STBu9O_ltp4cHw",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test Spreadsheet"
+            }
+          ],
+          "incompleteSearch": false,
+          "kind": "drive#fileList"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%27application%2Fvnd.google-apps.spreadsheet%27&pageSize=1000&supportsTeamDrives=True&includeTeamDriveItems=True"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n  \"updates\": {\n    \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n    \"updatedRange\": \"wksht_test!A1:C1\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:34 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+          "updates": {
+            "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A1:C1",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"test_append_row_with_empty_value_and_table_range 1\", \"\", \"test_append_row_with_empty_value_and_table_range 3\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "126"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test%21A1:append?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n  \"tableRange\": \"wksht_test!A1\",\n  \"updates\": {\n    \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n    \"updatedRange\": \"wksht_test!A2:C2\",\n    \"updatedRows\": 1,\n    \"updatedColumns\": 3,\n    \"updatedCells\": 3\n  }\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:34 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+          "tableRange": "wksht_test!A1",
+          "updates": {
+            "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E",
+            "updatedCells": 3,
+            "updatedColumns": 3,
+            "updatedRange": "wksht_test!A2:C2",
+            "updatedRows": 1
+          }
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test%21A1:append?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A2:T2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"test_append_row_with_empty_value_and_table_range 1\",\n      \"\",\n      \"test_append_row_with_empty_value_and_table_range 3\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:34 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A2:T2",
+          "values": [
+            [
+              "test_append_row_with_empty_value_and_table_range 1",
+              "",
+              "test_append_row_with_empty_value_and_table_range 3"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E/values/wksht_test%21A2%3A2?valueRenderOption=FORMATTED_VALUE"
+      }
+    },
+    {
+      "recorded_at": "2020-02-17T18:13:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 55756985}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 55756985
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 17 Feb 2020 18:13:35 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1TkoUZEsUhnQdOl8gw3ABWkOEbUcrqa_yI0JupdQPQ4E:batchUpdate"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -245,7 +245,6 @@ class ClientTest(GspreadTest):
         self.assertEqual(error.exception.args[0]['status'], 'NOT_FOUND')
 
 
-
 class SpreadsheetTest(GspreadTest):
 
     """Test for gspread.Spreadsheet."""
@@ -362,6 +361,7 @@ class SpreadsheetTest(GspreadTest):
             for rowix, ele in enumerate(rng['values']):
                 self.assertEqual(values[rowix][colix], ele[0])
         self.spreadsheet.del_worksheet(worksheet)
+
 
 class WorksheetTest(GspreadTest):
 
@@ -693,6 +693,30 @@ class WorksheetTest(GspreadTest):
         value_list = [next(sg) for i in range(10)]
         self.sheet.append_row(value_list)
         read_values = self.sheet.row_values(1)
+        self.assertEqual(value_list, read_values)
+
+    def test_append_row_with_empty_value(self):
+        sg = self._sequence_generator()
+        value_list = [next(sg) for i in range(3)]
+        value_list[1] = ''  # Skip one cell to create two "tables" as in #537
+        self.sheet.append_row(value_list)
+        # Append it again
+        self.sheet.append_row(value_list)
+        # This should produce a shift in rows as in #537
+        shifted_value_list = ['', ''] + value_list
+        read_values = self.sheet.row_values(2)
+        self.assertEqual(shifted_value_list, read_values)
+
+    def test_append_row_with_empty_value_and_table_range(self):
+        sg = self._sequence_generator()
+        value_list = [next(sg) for i in range(3)]
+        value_list[1] = ''  # Skip one cell to create two "tables" as in #537
+        self.sheet.append_row(value_list)
+        # Append it again
+        self.sheet.append_row(value_list, table_range='A1')
+        # This should produce no shift in rows
+        # contrary to test_append_row_with_empty_value
+        read_values = self.sheet.row_values(2)
         self.assertEqual(value_list, read_values)
 
     def test_insert_row(self):


### PR DESCRIPTION
To address #537 this PR adds two parameters to `Worksheet.append_row()`:
	- `table_range`
	- `insert_data_option`

This lets the user specify exactly which logical table the Sheets should use to append the row.