### PR TITLE
When Sheet names in A1 Notation, get_all_values fetching from one cell alone #636

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -690,8 +690,9 @@ class Worksheet(object):
             Empty trailing rows and columns will not be included.
         """
 
+        title = self.title.replace("'", "''")
         data = self.spreadsheet.values_get(
-            "'{}'".format(self.title),
+            "'{}'".format(title),
             params={'valueRenderOption': value_render_option}
         )
 


### PR DESCRIPTION
Hi,
When the sheet name is in A1 Notation, get_all_values only return value from one single cell.
Wrapping them with quotes (like this 'A1') fixes the issue. In case of sheet name already contains a single quotes, we need to escape it with another single quote. 