### PR TITLE
Fill in same value for all merged cells when calling get_all_values

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -23,7 +23,8 @@ from .utils import (
     filter_dict_values,
     absolute_range_name,
     a1_range_to_grid_range,
-    accepted_kwargs
+    accepted_kwargs,
+    fix_merge_values
 )
 
 from .urls import (
@@ -732,9 +733,18 @@ class Worksheet(object):
             "'{}'".format(title),
             params={'valueRenderOption': value_render_option}
         )
+        spreadsheet_meta = self.spreadsheet.fetch_sheet_metadata()
+
+        # not catching StopIteration becuase Worksheet exists
+        # potential issue if this Worksheet
+        worksheet_meta = finditem(
+            lambda x: x['properties']['title'] == self.title,
+            spreadsheet_meta['sheets']
+        )
 
         try:
-            return fill_gaps(data['values'])
+            values = fill_gaps(data['values'])
+            return fix_merge_values(worksheet_meta, values)
         except KeyError:
             return []
 

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -736,7 +736,7 @@ class Worksheet(object):
         spreadsheet_meta = self.spreadsheet.fetch_sheet_metadata()
 
         # not catching StopIteration becuase Worksheet exists
-        # potential issue if this Worksheet
+        # potential issue if this Worksheet is deleted
         worksheet_meta = finditem(
             lambda x: x['properties']['title'] == self.title,
             spreadsheet_meta['sheets']

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -533,6 +533,23 @@ def accepted_kwargs(**default_kwargs):
     return decorate
 
 
+def fix_merge_values(worksheet_metadata, values):
+    """Assign the top-left value to all cells in a merged range."""
+    for merge in worksheet_metadata.get("merges", []):
+        start_row, end_row = merge["startRowIndex"], merge["endRowIndex"]
+        start_col, end_col = (merge["startColumnIndex"], merge["endColumnIndex"])
+
+        # ignore merge cells outside the data range
+        if start_row < len(values) and start_col < len(values[0]):
+            orig_val = values[start_row][start_col]
+            for row in values[start_row:end_row]:
+                row[start_col:end_col] = [
+                    orig_val for i in range(start_col, end_col)
+                ]
+
+    return values
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod()

--- a/tests/test.py
+++ b/tests/test.py
@@ -743,6 +743,11 @@ class WorksheetTest(GspreadTest):
         # values should match with original lists
         self.assertEqual(read_data, rows)
 
+        # test that merged values are all filled in
+        self.sheet.merge_cells(0, 4, 0, 4)
+        read_data = self.sheet.get_all_values()
+        self.assertEqual(read_data, [[row[0] for _ in range(4)] for row in rows])
+
     def test_get_all_values_title_is_a1_notation(self):
         self.sheet.resize(4, 4)
         # renames sheet to contain single and double quotes


### PR DESCRIPTION
Fixes #700

Thought about making this an option, but it seems like it should just be the default behavior.