### PR TITLE
Improve merge_cells and add merge_type parameter

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1751,23 +1751,28 @@ class Worksheet(object):
             new_sheet_name
         )
 
-    def merge_cells(
-        self,
-        startRowIndex,
-        endRowIndex,
-        startColIndex,
-        endColIndex
-    ):
-        """Merge cells, using index coordonates.
+    @cast_to_a1_notation
+    def merge_cells(self, name):
+        """
+        Merge cells.
 
-        :param int startRowIndex: index of the row where merge start
-        :param int endRowIndex: index of the row where merge stops
-        :param int startColIndex: index of the column where merge starts
-        :param int endColIndex: index of the column where merge stops
+        :param name: A string with range value in A1 notation, e.g. 'A1:A5'.
+
+        Alternatively, you may specify numeric boundaries. All values
+        index from 1 (one):
+
+        :param first_row: Integer row number
+        :param first_col: Integer row number
+        :param last_row: Integer row number
+        :param last_col: Integer row number
 
         :return the response body from the request
         """
 
+        start, end = name.split(':')
+        (row_offset, column_offset) = a1_to_rowcol(start)
+        (last_row, last_column) = a1_to_rowcol(end)
+        
         body = {
             "requests": [
                 {
@@ -1775,10 +1780,10 @@ class Worksheet(object):
                         "mergeType": "MERGE_ROWS",
                         "range": {
                             "sheetId": self.id,
-                            "startRowIndex": startRowIndex,
-                            "endRowIndex": endRowIndex,
-                            "startColumnIndex": startColIndex,
-                            "endColumnIndex": endColIndex,
+                            "startRowIndex": row_offset - 1,
+                            "endRowIndex": last_row,
+                            "startColumnIndex": column_offset - 1,
+                            "endColumnIndex": last_column,
                         }
                     }
                 }

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1752,11 +1752,14 @@ class Worksheet(object):
         )
 
     @cast_to_a1_notation
-    def merge_cells(self, name):
+    def merge_cells(self, name, merge_type="MERGE_ROWS"):
         """
-        Merge cells.
+        Merge cells. There are 3 merge types: MERGE_ROWS, MERGE_COLUMNS,
+        and MERGE_ALL.
 
         :param name: A string with range value in A1 notation, e.g. 'A1:A5'.
+        :param merge_type: (optional) one of MERGE_ROWS, MERGE_COLUMNS,
+                           or MERGE_ALL. Default MERGE_ROWS
 
         Alternatively, you may specify numeric boundaries. All values
         index from 1 (one):
@@ -1777,7 +1780,7 @@ class Worksheet(object):
             "requests": [
                 {
                     "mergeCells": {
-                        "mergeType": "MERGE_ROWS",
+                        "mergeType": merge_type,
                         "range": {
                             "sheetId": self.id,
                             "startRowIndex": row_offset - 1,

--- a/tests/test.py
+++ b/tests/test.py
@@ -1074,5 +1074,11 @@ class CellTest(GspreadTest):
     def test_merge_cells(self):
         self.sheet.update_cell(1, 1, '42')
         self.sheet.update_cell(1, 2, '80')
+
         self.sheet.merge_cells(1, 1, 1, 2)
-        cell = self.sheet.cell(1, 1)
+
+        meta = self.sheet.spreadsheet.fetch_sheet_metadata()
+        merges = utils.finditem(
+            lambda x: x['properties']['sheetId'] == self.sheet.id, meta
+        )['merges']
+        self.assertEqual(len(merges), 2)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1075,6 +1075,7 @@ class CellTest(GspreadTest):
         self.sheet.update_cell(1, 1, '42')
         self.sheet.update_cell(1, 2, '80')
 
+        # test merge rows
         self.sheet.merge_cells(1, 1, 1, 2)
 
         meta = self.sheet.spreadsheet.fetch_sheet_metadata()
@@ -1082,3 +1083,13 @@ class CellTest(GspreadTest):
             lambda x: x['properties']['sheetId'] == self.sheet.id, meta
         )['merges']
         self.assertEqual(len(merges), 2)
+
+        # test merge all
+        self.sheet.merge_cells(1, 1, 1, 2, merge_type="MERGE_ALL")
+
+        meta = self.sheet.spreadsheet.fetch_sheet_metadata()
+        merges = utils.finditem(
+            lambda x: x['properties']['sheetId'] == self.sheet.id, meta
+        )['merges']
+        
+        self.assertEqual(len(merges), 1)


### PR DESCRIPTION
Various fixes to the `merge_cells` function including:

- Allowing A1 range name notation
- Fixing tests so it actually tests it works
- Add merge_type parameter