### PR TITLE
Support old and new collections.abc.Sequence

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -11,7 +11,11 @@ This module contains utility functions.
 import sys
 import re
 from functools import wraps
-from collections import defaultdict, Sequence
+from collections import defaultdict
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from itertools import chain
 
 from google.auth.credentials import Credentials as Credentials


### PR DESCRIPTION
Fixes #744

python3.9 fails if loading gspread.util

Steps to reproduce the behavior:

docker run -it python:3.9.0a5-buster
import("os").system("bash")
pip install gspread
exit
import gspread.util