### PR TITLE
Fix sheet names quoting

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -425,17 +425,37 @@ def quote(value, safe='', encoding='utf-8'):
     return urllib.quote(value.encode(encoding), safe)
 
 
-def absolute_range_name(sheet_name, range_name):
+def absolute_range_name(sheet_name, range_name=None):
     """Return an absolutized path of a range.
 
-    >>> absolute_range_name('Sheet1', 'A1:B1')
-    'Sheet1!A1:B1'
+    >>> absolute_range_name("Sheet1", "A1:B1")
+    "'Sheet1'!A1:B1"
 
-    >>> absolute_range_name('Sheet1', 'A1')
-    'Sheet1!A1'
+    >>> absolute_range_name("Sheet1", "A1")
+    "'Sheet1'!A1"
+
+    >>> absolute_range_name("Sheet1")
+    "'Sheet1'"
+
+    >>> absolute_range_name("Sheet'1")
+    "'Sheet''1'"
+
+    >>> absolute_range_name("Sheet''1")
+    "'Sheet''''1'"
+
+    >>> absolute_range_name("''sheet12''", "A1:B2")
+    "'''''sheet12'''''!A1:B2"
 
     """
-    return '%s!%s' % (sheet_name, range_name)
+
+    sheet_name = "'{}'".format(
+        sheet_name.replace("'", "''")
+    )
+
+    if range_name:
+        return '{}!{}'.format(sheet_name, range_name)
+    else:
+        return sheet_name
 
 
 def is_scalar(x):

--- a/tests/cassettes/WorksheetTest.test_update_and_get.json
+++ b/tests/cassettes/WorksheetTest.test_update_and_get.json
@@ -1,96 +1,6 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2020-04-03T19:36:55",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Authorization": [
-            "Bearer <ACCESS_TOKEN>"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "User-Agent": [
-            "python-requests/2.20.0"
-          ],
-          "accept-encoding": [
-            "identity"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%22application%2Fvnd.google-apps.spreadsheet%22+and+name+%3D+%22Test+WorksheetTest%22&pageSize=1000&supportsAllDrives=True&includeItemsFromAllDrives=True"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\n \"kind\": \"drive#fileList\",\n \"incompleteSearch\": false,\n \"files\": [\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1HiIX72LGxzpVlGy2Sg0XjjGyFnaUlKgOxQhiZXs3L8w\",\n   \"name\": \"Test WorksheetTest\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  }\n ]\n}\n"
-        },
-        "headers": {
-          "Alt-Svc": [
-            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
-          ],
-          "Cache-Control": [
-            "private, max-age=0, must-revalidate, no-transform"
-          ],
-          "Content-Length": [
-            "254"
-          ],
-          "Content-Security-Policy": [
-            "frame-ancestors 'self'"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Fri, 03 Apr 2020 19:36:55 GMT"
-          ],
-          "Expires": [
-            "Fri, 03 Apr 2020 19:36:55 GMT"
-          ],
-          "Server": [
-            "GSE"
-          ],
-          "Vary": [
-            "Origin",
-            "X-Origin"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1; mode=block"
-          ]
-        },
-        "json_body": {
-          "files": [
-            {
-              "id": "1HiIX72LGxzpVlGy2Sg0XjjGyFnaUlKgOxQhiZXs3L8w",
-              "kind": "drive#file",
-              "mimeType": "application/vnd.google-apps.spreadsheet",
-              "name": "Test WorksheetTest"
-            }
-          ],
-          "incompleteSearch": false,
-          "kind": "drive#fileList"
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%22application%2Fvnd.google-apps.spreadsheet%22+and+name+%3D+%22Test+WorksheetTest%22&pageSize=1000&supportsAllDrives=True&includeItemsFromAllDrives=True"
-      }
-    },
-    {
       "recorded_at": "2020-04-03T19:36:56",
       "request": {
         "body": {
@@ -392,6 +302,704 @@
           "message": "OK"
         },
         "url": "https://sheets.googleapis.com/v4/spreadsheets/1HiIX72LGxzpVlGy2Sg0XjjGyFnaUlKgOxQhiZXs3L8w:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T15:38:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"A1\", \"B1\", \"\", \"D1\"], [\"\", \"b2\", \"\", \"\"], [\"\", \"\", \"\", \"\"], [\"A4\", \"B4\", \"\", \"D4\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "98"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "A1",
+              "B1",
+              "",
+              "D1"
+            ],
+            [
+              "",
+              "b2",
+              "",
+              ""
+            ],
+            [
+              "",
+              "",
+              "",
+              ""
+            ],
+            [
+              "A4",
+              "B4",
+              "",
+              "D4"
+            ]
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60/values/wksht_test%21A1?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60\",\n  \"updatedRange\": \"wksht_test!A1:D4\",\n  \"updatedRows\": 4,\n  \"updatedColumns\": 4,\n  \"updatedCells\": 16\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 15:38:46 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60",
+          "updatedCells": 16,
+          "updatedColumns": 4,
+          "updatedRange": "wksht_test!A1:D4",
+          "updatedRows": 4
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60/values/wksht_test%21A1?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T15:38:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60/values/wksht_test%21A1%3AD4"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A1:D4\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"A1\",\n      \"B1\",\n      \"\",\n      \"D1\"\n    ],\n    [\n      \"\",\n      \"b2\"\n    ],\n    [],\n    [\n      \"A4\",\n      \"B4\",\n      \"\",\n      \"D4\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 15:38:46 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A1:D4",
+          "values": [
+            [
+              "A1",
+              "B1",
+              "",
+              "D1"
+            ],
+            [
+              "",
+              "b2"
+            ],
+            [],
+            [
+              "A4",
+              "B4",
+              "",
+              "D4"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60/values/wksht_test%21A1%3AD4"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T15:38:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 1601625753}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "56"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 1601625753
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 15:38:46 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/10QCZrO3nzO-uPLfhTJfpB6IBgqVrhqwGZJaDCP-qc60:batchUpdate"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T16:19:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%22application%2Fvnd.google-apps.spreadsheet%22+and+name+%3D+%22Test+WorksheetTest%22&pageSize=1000&supportsAllDrives=True&includeItemsFromAllDrives=True"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n \"kind\": \"drive#fileList\",\n \"incompleteSearch\": false,\n \"files\": [\n  {\n   \"kind\": \"drive#file\",\n   \"id\": \"1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA\",\n   \"name\": \"Test WorksheetTest\",\n   \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n  }\n ]\n}\n"
+        },
+        "headers": {
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private, max-age=0, must-revalidate, no-transform"
+          ],
+          "Content-Length": [
+            "254"
+          ],
+          "Content-Security-Policy": [
+            "frame-ancestors 'self'"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 16:19:15 GMT"
+          ],
+          "Expires": [
+            "Sat, 04 Apr 2020 16:19:15 GMT"
+          ],
+          "Server": [
+            "GSE"
+          ],
+          "Vary": [
+            "Origin",
+            "X-Origin"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "json_body": {
+          "files": [
+            {
+              "id": "1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA",
+              "kind": "drive#file",
+              "mimeType": "application/vnd.google-apps.spreadsheet",
+              "name": "Test WorksheetTest"
+            }
+          ],
+          "incompleteSearch": false,
+          "kind": "drive#fileList"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%22application%2Fvnd.google-apps.spreadsheet%22+and+name+%3D+%22Test+WorksheetTest%22&pageSize=1000&supportsAllDrives=True&includeItemsFromAllDrives=True"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T16:19:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"values\": [[\"A1\", \"B1\", \"\", \"D1\"], [\"\", \"b2\", \"\", \"\"], [\"\", \"\", \"\", \"\"], [\"A4\", \"B4\", \"\", \"D4\"]]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "98"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "values": [
+            [
+              "A1",
+              "B1",
+              "",
+              "D1"
+            ],
+            [
+              "",
+              "b2",
+              "",
+              ""
+            ],
+            [
+              "",
+              "",
+              "",
+              ""
+            ],
+            [
+              "A4",
+              "B4",
+              "",
+              "D4"
+            ]
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA/values/wksht_test%21A1?valueInputOption=RAW"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA\",\n  \"updatedRange\": \"wksht_test!A1:D4\",\n  \"updatedRows\": 4,\n  \"updatedColumns\": 4,\n  \"updatedCells\": 16\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 16:19:16 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "spreadsheetId": "1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA",
+          "updatedCells": 16,
+          "updatedColumns": 4,
+          "updatedRange": "wksht_test!A1:D4",
+          "updatedRows": 4
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA/values/wksht_test%21A1?valueInputOption=RAW"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T16:19:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA/values/%27wksht_test%27%21A1%3AD4"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"range\": \"wksht_test!A1:D4\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      \"A1\",\n      \"B1\",\n      \"\",\n      \"D1\"\n    ],\n    [\n      \"\",\n      \"b2\"\n    ],\n    [],\n    [\n      \"A4\",\n      \"B4\",\n      \"\",\n      \"D4\"\n    ]\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 16:19:16 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "majorDimension": "ROWS",
+          "range": "wksht_test!A1:D4",
+          "values": [
+            [
+              "A1",
+              "B1",
+              "",
+              "D1"
+            ],
+            [
+              "",
+              "b2"
+            ],
+            [],
+            [
+              "A4",
+              "B4",
+              "",
+              "D4"
+            ]
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA/values/%27wksht_test%27%21A1%3AD4"
+      }
+    },
+    {
+      "recorded_at": "2020-04-04T16:19:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"requests\": [{\"deleteSheet\": {\"sheetId\": 1443563167}}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "56"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.20.0"
+          ],
+          "accept-encoding": [
+            "identity"
+          ]
+        },
+        "json_body": {
+          "requests": [
+            {
+              "deleteSheet": {
+                "sheetId": 1443563167
+              }
+            }
+          ]
+        },
+        "method": "POST",
+        "uri": "https://sheets.googleapis.com/v4/spreadsheets/1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA:batchUpdate"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\n  \"spreadsheetId\": \"1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "none"
+          ],
+          "Alt-Svc": [
+            "quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000"
+          ],
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 04 Apr 2020 16:19:17 GMT"
+          ],
+          "Server": [
+            "ESF"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "X-Origin",
+            "Referer",
+            "Origin,Accept-Encoding"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "0"
+          ]
+        },
+        "json_body": {
+          "replies": [
+            {}
+          ],
+          "spreadsheetId": "1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/1vT-jJo5qK19wnxjJ2hZeWM0U947y5IJfkZhYkiXlZaA:batchUpdate"
       }
     }
   ],


### PR DESCRIPTION
1. Extend `utils.absolute_range_name` to handle missing `range_name` parameter.
2. Wrap sheet name in single quotes and escape single quotes.
3. Use `utils.absolute_range_name` throughout `gspread.models` to construct proper range names.