### PR TITLE
Fix `TypeError` when using gspread in google colab

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -48,7 +48,11 @@ def convert_credentials(credentials):
     cls = credentials.__class__.__name__
     if 'oauth2client' in module and cls == 'ServiceAccountCredentials':
         return _convert_service_account(credentials)
-    elif 'oauth2client' in module and cls == 'OAuth2Credentials':
+    elif 'oauth2client' in module and cls in (
+        'OAuth2Credentials',
+        'AccessTokenCredentials',
+        'GoogleCredentials'
+    ):
         return _convert_oauth(credentials)
     elif isinstance(credentials, Credentials):
         return credentials


### PR DESCRIPTION
`gspread.authorize()` fails when using the example from google colab [External Data](https://colab.research.google.com/notebooks/io.ipynb#scrollTo=sOm9PFrT8mGG):

```python
from google.colab import auth
auth.authenticate_user()

import gspread
from oauth2client.client import GoogleCredentials

gc = gspread.authorize(GoogleCredentials.get_application_default())
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-20-c377298b0a7e> in <module>()
----> 1 gc = gspread.authorize(GoogleCredentials.get_application_default())

2 frames
/usr/local/lib/python3.6/dist-packages/gspread/utils.py in convert_credentials(credentials)
     55 
     56     raise TypeError(
---> 57         'Credentials need to be from either oauth2client or from google-auth.'
     58     )
     59 

TypeError: Credentials need to be from either oauth2client or from google-auth.
```

This quickfix expands `convert_credentials` to handle conversion of other cred classes from `oauth2client`.