### PR TITLE
Simplified OAuth2 flow

### DIFF
--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -13,6 +13,7 @@ __version__ = '3.4.2'
 __author__ = 'Anton Burnashev'
 
 
+from .auth import oauth
 from .client import Client
 from .models import Spreadsheet, Worksheet, Cell
 

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -25,12 +25,34 @@ READONLY_SCOPES = [
 ]
 
 
-DEFAULT_CONFIG_DIR = os.path.expanduser('~/.config/gspread')
+def get_config_dir(config_dir_name='gspread', os_is_windows=os.name == 'nt'):
+    """Construct a config dir path.
+
+    By default:
+        * `%APPDATA%\gspread` on Windows
+        * `~/.config/gspread` everywhere else
+
+    """
+    if os_is_windows:
+        return os.path.join(
+            os.environ["APPDATA"],
+            config_dir_name
+        )
+    else:
+        return os.path.join(
+            os.path.expanduser('~'),
+            '.config',
+            config_dir_name
+        )
+
+
+DEFAULT_CONFIG_DIR = get_config_dir()
+
 DEFAULT_CREDENTIALS_FILENAME = os.path.join(
     DEFAULT_CONFIG_DIR,
     'credentials.json'
 )
-DEFAULT_AUTHORIZED_USER_FILE = os.path.join(
+DEFAULT_AUTHORIZED_USER_FILENAME = os.path.join(
     DEFAULT_CONFIG_DIR,
     'authorized_user.json'
 )
@@ -53,7 +75,7 @@ def console_flow(scopes):
     return flow.run_console()
 
 
-def load_credentials(filename=DEFAULT_AUTHORIZED_USER_FILE):
+def load_credentials(filename=DEFAULT_AUTHORIZED_USER_FILENAME):
     if os.path.exists(filename):
         return Credentials.from_authorized_user_file(filename)
 
@@ -62,7 +84,7 @@ def load_credentials(filename=DEFAULT_AUTHORIZED_USER_FILE):
 
 def store_credentials(
     creds,
-    filename=DEFAULT_AUTHORIZED_USER_FILE,
+    filename=DEFAULT_AUTHORIZED_USER_FILENAME,
     strip='token'
 ):
     with open(filename, 'w') as f:

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+"""
+gspread.auth
+~~~~~~~~~~~~
+
+Simple authentication with OAuth.
+
+"""
+
+import os
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+from .client import Client
+
+DEFAULT_SCOPES = [
+    'https://www.googleapis.com/auth/spreadsheets',
+    'https://www.googleapis.com/auth/drive'
+]
+
+READONLY_SCOPES = [
+    'https://www.googleapis.com/auth/spreadsheets.readonly',
+    'https://www.googleapis.com/auth/drive.readonly'
+]
+
+
+DEFAULT_CONFIG_DIR = os.path.expanduser('~/.config/gspread')
+DEFAULT_CREDENTIALS_FILENAME = os.path.join(
+    DEFAULT_CONFIG_DIR,
+    'credentials.json'
+)
+DEFAULT_AUTHORIZED_USER_FILE = os.path.join(
+    DEFAULT_CONFIG_DIR,
+    'authorized_user.json'
+)
+
+
+def _create_installed_app_flow(scopes):
+    return InstalledAppFlow.from_client_secrets_file(
+        DEFAULT_CREDENTIALS_FILENAME,
+        scopes
+    )
+
+
+def local_server_flow(scopes, port=0):
+    flow = _create_installed_app_flow(scopes)
+    return flow.run_local_server(port=port)
+
+
+def console_flow(scopes):
+    flow = _create_installed_app_flow(scopes)
+    return flow.run_console()
+
+
+def load_credentials(filename=DEFAULT_AUTHORIZED_USER_FILE):
+    if os.path.exists(filename):
+        return Credentials.from_authorized_user_file(filename)
+
+    return None
+
+
+def store_credentials(
+    creds,
+    filename=DEFAULT_AUTHORIZED_USER_FILE,
+    strip='token'
+):
+    with open(filename, 'w') as f:
+        f.write(creds.to_json(strip))
+
+
+def oauth(scopes=DEFAULT_SCOPES, flow=local_server_flow):
+    creds = load_credentials()
+
+    if not creds:
+        creds = flow(scopes=scopes)
+        store_credentials(creds)
+
+    client = Client(auth=creds)
+    return client

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ setup(
     author_email='fuss.here@gmail.com',
     url='https://github.com/burnash/gspread',
     keywords=['spreadsheets', 'google-spreadsheets'],
-    install_requires=['requests>=2.2.1', 'google-auth'],
+    install_requires=[
+        'requests>=2.2.1',
+        'google-auth>=1.12.0',
+        'google-auth-oauthlib>=0.4.1'
+    ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Programming Language :: Python",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 nose
-requests[security]
 google-auth
+google-auth-oauthlib>=0.4.1
 betamax==0.8.1
 -e git+https://github.com/burnash/betamax-json-body-serializer.git#egg=betamax_json_body_serializer


### PR DESCRIPTION
This is a first attempt to implement a simplified authentication for gspread. Inspired by excellent [gspread-pandas](https://github.com/aiguofer/gspread-pandas) I'd like to cut down the boilerplate for constructing credentials, so you can get the authorized client instance in your code with just:

```
import gspread
gc = gspread.oauth()
```

On the first run, this will look for OAuth 2.0 Client credentials in `~/.config/gspread/credentials.json`, open a browser window with the application authorization request, get the user's consent and store authorized credentials in the config directory. Next runs will use stored credentials.

Open questions:
1. Credentials security.
2. Default scope.
3. With this added convenience, should client credentials replace service accounts as recommended flow in the docs. This is related to (1) and (2) since a service account does not have access to any spreadsheet unless a spreadsheet is explicitly shared with this account. Using OAuth 2.0 Client credentials, on the other hand, gives the script direct access to the user data. 