### PR TITLE
Add ability to create cell instance using A1 notation

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1894,6 +1894,10 @@ class Cell(object):
         #: Value of the cell.
         self.value = value
 
+    @classmethod
+    def from_address(cls, label, value=''):
+        return cls(*a1_to_rowcol(label), value=value)
+
     def __repr__(self):
         return '<%s R%sC%s %s>' % (self.__class__.__name__,
                                    self.row,

--- a/tests/test.py
+++ b/tests/test.py
@@ -1094,6 +1094,10 @@ class CellTest(GspreadTest):
         self.assertEqual(cell.value, 'Dummy')
         cell = gspread.models.Cell(1, 2, 'Foo Bar')
         self.assertEqual(cell.address, 'B1')
+        cell = gspread.models.Cell.from_address('A1', 'Foo Bar')
+        self.assertEqual(cell.address, 'A1')
+        self.assertEqual(cell.value, 'Foo Bar')
+        self.assertEqual((cell.row, cell.col), (1, 1))
 
     def test_merge_cells(self):
         self.sheet.update('A1:B2', [[42, 43], [43, 44]])


### PR DESCRIPTION
Naturally when we deal with Google Spreadsheets we'd like
to operate with letters (in A1 notation), rather then decimal
row/col addressing mode. This patch adds an ability to create
cells using A1 notation, eg.:

   cells = [Cell.from_address(f'A{i}', value=i) for i in range(1, 10)]
   self.sheet.update_cells(cells)