### PR TITLE
Add `auth.service_account()`

### DIFF
--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -13,7 +13,7 @@ __version__ = '3.5.0'
 __author__ = 'Anton Burnashev'
 
 
-from .auth import oauth
+from .auth import oauth, service_account
 from .client import Client
 from .models import Spreadsheet, Worksheet, Cell
 

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -10,6 +10,9 @@ Simple authentication with OAuth.
 
 import os
 from google.oauth2.credentials import Credentials
+from google.oauth2.service_account import (
+    Credentials as ServiceAccountCredentials,
+)
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 from .client import Client
@@ -56,6 +59,10 @@ DEFAULT_AUTHORIZED_USER_FILENAME = os.path.join(
     DEFAULT_CONFIG_DIR,
     'authorized_user.json'
 )
+DEFAULT_SERVICE_ACCOUNT_FILENAME = os.path.join(
+    DEFAULT_CONFIG_DIR,
+    'service_account.json'
+)
 
 
 def _create_installed_app_flow(scopes):
@@ -100,3 +107,14 @@ def oauth(scopes=DEFAULT_SCOPES, flow=local_server_flow):
 
     client = Client(auth=creds)
     return client
+
+
+def service_account(
+    scopes=DEFAULT_SCOPES,
+    filename=DEFAULT_SERVICE_ACCOUNT_FILENAME
+):
+    creds = ServiceAccountCredentials.from_service_account_file(
+        filename,
+        scopes=scopes
+    )
+    return Client(auth=creds)


### PR DESCRIPTION
Simplify auth with service accounts. This PR adds `gspread.service_account()` which wraps `Credentials.from_service_account_file` cutting down initialization code.

So instead of 

```python
import gspread
from google.oauth2.service_account import Credentials

scopes = ['https://spreadsheets.google.com/feeds',
         'https://www.googleapis.com/auth/drive']

credentials = Credentials.from_service_account_file(
    'path/to/the/downloaded/file.json', 
    scopes=scopes
)

gc = gspread.authorize(credentials)
```

You put your service account key in `~/.config/gspread/service_account.json` and `service_account()` does the rest:

```python
import gspread
gc = gspread.service_account()

```

