### PR TITLE
Allow auth to be None. Fix #773

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -27,7 +27,7 @@ Using ``Authlib`` instead of ``google-auth``. Similar to `google.auth.transport.
 
     import json
     from gspread import Client
-    from authlib.client import AssertionSession
+    from authlib.integrations.requests_client import AssertionSession
 
     def create_assertion_session(conf_file, scopes, subject=None):
         with open(conf_file, 'r') as f:

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -36,8 +36,11 @@ class Client(object):
     """
 
     def __init__(self, auth, session=None):
-        self.auth = convert_credentials(auth)
-        self.session = session or AuthorizedSession(self.auth)
+        if auth is not None:
+            self.auth = convert_credentials(auth)
+            self.session = session or AuthorizedSession(self.auth)
+        else:
+            self.session = session
 
     def login(self):
         from google.auth.transport.requests import Request


### PR DESCRIPTION
This fixed https://github.com/burnash/gspread/issues/773

cc @burnash I'd like to suggest using Authlib instead of `google.auth`. With Authlib, you just need to add very little code for the auth part in gspread. Check out: https://blog.authlib.org/2018/authlib-for-gspread