### PR TITLE
Add get_values() to Worksheet

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -704,30 +704,105 @@ class Worksheet(object):
             for j, value in enumerate(row)
         ]
 
-    def get_all_values(self, value_render_option='FORMATTED_VALUE'):
-        """Returns a list of lists containing all cells' values as strings.
+    @accepted_kwargs(
+        major_dimension=None,
+        value_render_option=None,
+        date_time_render_option=None,
+    )
+    def get_values(self, range_name=None, **kwargs):
+        """Returns a list of lists containing all values from specified range.
 
-        :param value_render_option: (optional) Determines how values should be
-                                    rendered in the the output. See
-                                    `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option: str
+        By default values are returned as strings. See ``value_render_option``
+        to change the default format.
+
+        :param str range_name: (optional) Cell range in the A1 notation or
+            a named range. If not specified the method returns values from all
+            non empty cells.
+
+        :param str major_dimension: (optional) The major dimension of the
+            values. Either ``ROWS`` or ``COLUMNS``. Defaults to ``ROWS``
+
+        :param str value_render_option: (optional) Determines how values should
+            be rendered in the the output. See `ValueRenderOption`_ in
+            the Sheets API.
+
+            Possible values are:
+
+            ``FORMATTED_VALUE``
+                (default) Values will be calculated and formatted according
+                to the cell's formatting. Formatting is based on the
+                spreadsheet's locale, not the requesting user's locale.
+
+            ``UNFORMATTED_VALUE``
+                Values will be calculated, but not formatted in the reply.
+                For example, if A1 is 1.23 and A2 is =A1 and formatted as
+                currency, then A2 would return the number 1.23.
+
+            ``FORMULA``
+                Values will not be calculated. The reply will include
+                the formulas. For example, if A1 is 1.23 and A2 is =A1 and
+                formatted as currency, then A2 would return "=A1".
 
         .. _ValueRenderOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption
+
+        :param str date_time_render_option: (optional) How dates, times, and
+            durations should be represented in the output. This is ignored if
+            ``value_render_option`` is ``FORMATTED_VALUE``. The default
+            ``date_time_render_option`` is ``SERIAL_NUMBER``.
 
         .. note::
 
             Empty trailing rows and columns will not be included.
+
+        Examples::
+
+            # Return all values from the sheet
+            worksheet.get_values()
+
+            # Return all values from colums "A" and "B"
+            worksheet.get_values('A:B')
+
+            # Return values from range "A2:C10"
+            worksheet.get_values('A2:C10')
+
+            # Return values from named range "my_range"
+            worksheet.get_values('my_range')
+
+            # Return unformatted values (e.g. numbers as numbers)
+            worksheet.get_values('A2:B4', value_render_option='UNFORMATTED_VALUE')
+
+            # Return cell values without calculating formulas
+            worksheet.get_values('A2:B4', value_render_option='FORMULA')
         """
-        range_name = absolute_range_name(self.title)
-
-        data = self.spreadsheet.values_get(
-            range_name, params={'valueRenderOption': value_render_option}
-        )
-
         try:
-            return fill_gaps(data['values'])
+            return fill_gaps(self.get(range_name, **kwargs))
         except KeyError:
             return []
+
+    @accepted_kwargs(
+        major_dimension=None,
+        value_render_option=None,
+        date_time_render_option=None,
+    )
+    def get_all_values(self, **kwargs):
+        """Returns a list of lists containing all cells' values as strings.
+
+        This is an alias to :meth:`~gspread.models.Worksheet.get_values`
+
+        .. note::
+
+            This is a legacy method.
+            Use :meth:`~gspread.models.Worksheet.get_values` instead.
+
+        Examples::
+
+            # Return all values from the sheet
+            worksheet.get_all_values()
+
+            # Is equivalent to
+            worksheet.get_values()
+        """
+        return self.get_values(**kwargs)
 
     def get_all_records(
         self,
@@ -944,8 +1019,8 @@ class Worksheet(object):
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            value_render_option is ``FORMATTED_VALUE``. The default dateTime
-            render option is ``SERIAL_NUMBER``.
+            ``value_render_option`` is ``FORMATTED_VALUE``. The default
+            ``date_time_render_option`` is ``SERIAL_NUMBER``.
 
         Examples::
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -426,15 +426,18 @@ def rightpad(row, max_len):
 
 def fill_gaps(L, rows=None, cols=None):
 
-    max_cols = max(len(row) for row in L) if cols is None else cols
-    max_rows = len(L) if rows is None else rows
+    try:
+        max_cols = max(len(row) for row in L) if cols is None else cols
+        max_rows = len(L) if rows is None else rows
 
-    pad_rows = max_rows - len(L)
+        pad_rows = max_rows - len(L)
 
-    if pad_rows:
-        L = L + ([[]] * pad_rows)
+        if pad_rows:
+            L = L + ([[]] * pad_rows)
 
-    return [rightpad(row, max_cols) for row in L]
+        return [rightpad(row, max_cols) for row in L]
+    except ValueError:
+        return []
 
 
 def cell_list_to_rect(cell_list):


### PR DESCRIPTION
This PR adds a more flexible alternative to `get_all_values()`:

```python
    # Return all values from the sheet
    worksheet.get_values()

    # Return all values from colums "A" and "B"
    worksheet.get_values('A:B')

    # Return values from range "A2:C10"
    worksheet.get_values('A2:C10')

    # Return values from named range "my_range"
    worksheet.get_values('my_range')
```