### PR TITLE
fix editor_users_emails - get only from list not all who had access t…

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1629,14 +1629,7 @@ class Worksheet(object):
             who requested this protected range can edit the protected cells.
             Defaults to ``False``.
         """
-        email_address = [
-            permission.get('emailAddress')
-            for permission in self.client.list_permissions(self.spreadsheet.id)
-            if permission.get('emailAddress')
-        ]
-
-        editors_emails = editor_users_emails or []
-        email_address.extend(email for email in editors_emails)
+        editor_users_emails = editor_users_emails or []
 
         editor_groups_emails = editor_groups_emails or []
 
@@ -1652,7 +1645,7 @@ class Worksheet(object):
                             "warningOnly": warning_only,
                             "requestingUserCanEdit": requesting_user_can_edit,
                             "editors": {
-                                "users": email_address,
+                                "users": editor_users_emails,
                                 "groups": editor_groups_emails,
                             },
                         }


### PR DESCRIPTION
Fix for editor_users_emails.
It was setup to extend list of editor_users_emails for all users who had access to spreadsheet.
Change to users only from editor_users_emails.