### PR TITLE
Changed find() return to None if nothing found

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1780,7 +1780,7 @@ class Worksheet(object):
         try:
             return self._finder(finditem, query, in_row, in_column)
         except StopIteration:
-            raise CellNotFound(query)
+            return None
 
     def findall(self, query, in_row=None, in_column=None):
         """Finds all cells matching the query.


### PR DESCRIPTION
Very minor tweak, find() should return something if nothing was found. It's likely that sometime you won't find the cell and returning None seems more practical than raising an exception