### PR TITLE
fix: no exception if file with credentials doesn't exist

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -100,7 +100,7 @@ def load_credentials(filename=DEFAULT_AUTHORIZED_USER_FILENAME):
 def store_credentials(
     creds, filename=DEFAULT_AUTHORIZED_USER_FILENAME, strip='token'
 ):
-    with open(filename, 'w') as f:
+    with open(filename, 'w+') as f:
         f.write(creds.to_json(strip))
 
 


### PR DESCRIPTION
This fix will tell python to create a file with credentials if it doesn't exist. I believe this is expected behaviour because the client shouldn't manually create an empty file to store them