### PR TITLE
Update documentation Authentication:For End Users: Using OAuth Client ID

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -53,7 +53,7 @@ You will automatically download a JSON file with credentials. It may look like t
         ...
     }
 
-Remeber the path to the downloaded credentials file. Also, in the next step you'll need the value of *client_email* from this file.
+Remember the path to the downloaded credentials file. Also, in the next step you'll need the value of *client_email* from this file.
 
 6. Very important! Go to your spreadsheet and share it with a *client_email* from the step above. Just like you do with any other Google account. If you don't do this, you'll get a ``gspread.exceptions.SpreadsheetNotFound`` exception when trying to access this spreadsheet from your application or a script.
 
@@ -115,12 +115,18 @@ For End Users: Using OAuth Client ID
 This is the case where your application or a script is accessing spreadsheets on behalf of an end user. When you use this scenario, your application or a script will ask the end user (or yourself if you're running it) to grant access to the user's data.
 
 1. :ref:`enable-api-access` if you haven't done it yet.
-2. Go to "APIs & Services > OAuth Consent Screen." Click the button for "Configure Consent Screen" and follow the directions to give your app a name; you don't need to fill out anything else on that screen. Click Save. 
+#. Go to "APIs & Services > OAuth Consent Screen." Click the button for "Configure Consent Screen".
+
+  a. In the "1 OAuth consent screen" tab, give your app a name and fill the "User support email" and "Developer contact information". Click "SAVE AND CONTINUE".
+  #. There is no need to fill in anything in the tab "2 Scopes", just click "SAVE AND CONTINUE".
+  #. In the tab "3 Test users", add the Google account email of the end user, typically your own Google email. Click "SAVE AND CONTINUE".
+  #. Double check the "4 Summary" presented and click "BACK TO DASHBOARD".
+
 3. Go to "APIs & Services > Credentials"
-4. Click "+ Create credentials" at the top, then select "OAuth client ID".
-5. Select "Desktop app", name the credentials and click "Create". Click "Ok" in the "OAuth client created" popup.
-6. Download the credentials by clicking the Download JSON button in "OAuth 2.0 Client IDs" section.
-7. Move the downloaded file to ``~/.config/gspread/credentials.json``. Windows users should put this file to ``%APPDATA%\gspread\credentials.json``.
+#. Click "+ Create credentials" at the top, then select "OAuth client ID".
+#. Select "Desktop app", name the credentials and click "Create". Click "Ok" in the "OAuth client created" popup.
+#. Download the credentials by clicking the Download JSON button in "OAuth 2.0 Client IDs" section.
+#. Move the downloaded file to ``~/.config/gspread/credentials.json``. Windows users should put this file to ``%APPDATA%\gspread\credentials.json``.
 
 Create a new Python file with this code:
 


### PR DESCRIPTION
Simply following the steps in the documentation `Authentication : For End Users: Using OAuth Client ID`, didn't work for me to give `gspread` access to my Google Sheets.
I figured out that what was wrong, and simply adding my Google account mail to the `Test users` section in the `OAuth consent screen` configuration solved the problem. Otherwise, I was getting the following error in the browser asking me for authentication:

> Error 403: access_denied. The developer hasn’t given you access to this app.

I have searched through the [Issues](https://github.com/burnash/gspread/issues?q=is%3Aissue+is%3Aopen+error+403) and [StackOverflow](https://stackoverflow.com/search?tab=newest&q=%5bgspread%5d%20error%20403) and didn't find anything really matching this docu issue, thus this PR.
Rendering the docu change with Sphinx 3.4.1 and it looks fine on my side:
![imagen](https://user-images.githubusercontent.com/63038781/103269161-7ffb0e80-49b5-11eb-9c3a-915b9218a08c.png)

