### PR TITLE
feat: pass a filename to oauth()

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -119,7 +119,7 @@ For End Users: Using OAuth Client ID
 This is the case where your application or a script is accessing spreadsheets on behalf of an end user. When you use this scenario, your application or a script will ask the end user (or yourself if you're running it) to grant access to the user's data.
 
 1. :ref:`enable-api-access` if you haven't done it yet.
-2. Go to "APIs & Services > OAuth Consent Screen." Click the button for "Configure Consent Screen" and follow the directions to give your app a name; you don't need to fill out anything else on that screen. Click Save. 
+2. Go to "APIs & Services > OAuth Consent Screen." Click the button for "Configure Consent Screen" and follow the directions to give your app a name; you don't need to fill out anything else on that screen. Click Save.
 3. Go to "APIs & Services > Credentials"
 4. Click "+ Create credentials" at the top, then select "OAuth client ID".
 5. Select "Desktop app", name the credentials and click "Create". Click "Ok" in the "OAuth client created" popup.
@@ -140,6 +140,13 @@ Create a new Python file with this code:
 
 When you run this code, it launches a browser asking you for authentication. Follow the instruction on the web page. Once finished, gspread stores authorized credentials in the config directory next to `credentials.json`.
 You only need to do authorization in the browser once, following runs will reuse stored credentials.
+
+.. NOTE::
+    If you want to store the credentials file somewhere else, specify the path to `authorized_user.json` in :meth:`~gspread.oauth`:
+    ::
+        gc = gspread.oauth(authorized_user_filename='path/to/the/downloaded/file.json')
+
+    Make sure you store the credentials file in a safe place.
 
 .. attention:: Security
     Credentials file and authorized credentials contain sensitive data. **Do not share these files with others** and treat them like private keys.

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -104,7 +104,11 @@ def store_credentials(
         f.write(creds.to_json(strip))
 
 
-def oauth(scopes=DEFAULT_SCOPES, flow=local_server_flow):
+def oauth(
+    scopes=DEFAULT_SCOPES,
+    flow=local_server_flow,
+    authorized_user_filename=DEFAULT_AUTHORIZED_USER_FILENAME,
+):
     """Authenticate with OAuth Client ID.
 
     By default this function will use the local server strategy and open
@@ -138,14 +142,24 @@ def oauth(scopes=DEFAULT_SCOPES, flow=local_server_flow):
         sh = gc.open("A spreadsheet")
         sh.sheet1.update('A1', '42')   # <-- this will not work
 
+    If you're storing your user credentials in a place other than the
+    default, you may provide a path to that file like so::
+
+        gc = gspread.oauth(authorized_user_filename='/alternative/path/authorized_user.json')
+
 
     :param list scopes: The scopes used to obtain authorization.
     :param function flow: OAuth flow to use for authentication.
         Defaults to :meth:`~gspread.auth.local_server_flow`
+    :param str authorized_user_filename: Filepath (including name) pointing to
+        an authorized user `.json` file.
+        Defaults to DEFAULT_AUTHORIZED_USER_FILENAME:
+            * `%APPDATA%\gspread\authorized_user.json` on Windows
+            * `~/.config/gspread/authorized_user.json` everywhere else
 
     :rtype: :class:`gspread.Client`
     """
-    creds = load_credentials()
+    creds = load_credentials(filename=authorized_user_filename)
 
     if not creds:
         creds = flow(scopes=scopes)
@@ -206,6 +220,7 @@ def service_account_from_dict(info, scopes=DEFAULT_SCOPES):
     :rtype: :class:`gspread.Client`
     """
     creds = ServiceAccountCredentials.from_service_account_info(
-        info=info, scopes=scopes,
+        info=info,
+        scopes=scopes,
     )
     return Client(auth=creds)


### PR DESCRIPTION
# Aim
While `load_credentials()` allows for user's custom credentials path for service account credentials, `oauth()` doesn't but as discussed in #826 it looks like it is something several users would appreciate.

Given that `oauth()` simply wraps around `load_credentials()` it seems pretty straightforward to just allow `oauth()` to recieve an optional filename.

# Solution
- `oauth()` gets a an oprional `credentials_filename` argument which is then passed down to `load_credentials()` and defaults to `DEFAULT_AUTHORIZED_USER_FILENAME` so that the change is backward compatible with current documented usage.
- Adds documentation snippets
- Closes #826 

# To Reviewer's Attention
- I named the argument `credentials_filename`, however, I see that you folks generally just use `filename`, happy to keep things consistent here
- I also have black turned on by default on my IDE which resulted in a formatting change across the entire file. I imagine that's not entirely welcome in this project so I'm happy to go ahead and correct that back. Unless you'd like to use black across your project and I'd be happy to help with that.
- I couldn't find a unit test on the function I modified but let me know if I'm missing something
