### PR TITLE
Added feature get_worksheet_by_id

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -306,16 +306,13 @@ class Spreadsheet(object):
         sheet_data = self.fetch_sheet_metadata()
 
         try:
-            sheets_length = len(sheet_data['sheets'])
-            print(sheet_data['sheets'])
-            for i in range(0,sheets_length):
-                
-                if id == sheet_data['sheets'][i]['properties']['sheetId']:
-                    properties = sheet_data['sheets'][i]['properties']
-                    return Worksheet(self, properties)
-            raise WorksheetNotFound
-        except (KeyError):
-            return None
+            item = finditem(
+                lambda x: x['properties']['sheetId'] == id,
+                sheet_data['sheets'],
+            )
+            return Worksheet(self, item['properties'])
+        except (StopIteration, KeyError):
+            raise WorksheetNotFound(id)
 
     def worksheets(self):
         """Returns a list of all :class:`worksheets <gspread.models.Worksheet>`

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -288,6 +288,34 @@ class Spreadsheet(object):
             return Worksheet(self, properties)
         except (KeyError, IndexError):
             return None
+    
+    def get_worksheet_by_id(self, id):
+        """Returns a worksheet with specified `worksheet id`.
+
+        :param id: The id of a worksheet. it can be seen in the url as the value of the parameter 'gid'.
+        :type id: int
+
+        :returns: an instance of :class:`gspread.models.Worksheet`
+                  or `None` if the worksheet is not found.
+
+        Example. To get first worksheet of a spreadsheet:
+
+        >>> sht = client.open('My fancy spreadsheet')
+        >>> worksheet = sht.get_worksheet_by_id(0):rtype: dict
+        """
+        sheet_data = self.fetch_sheet_metadata()
+
+        try:
+            sheets_length = len(sheet_data['sheets'])
+            print(sheet_data['sheets'])
+            for i in range(0,sheets_length):
+                
+                if id == sheet_data['sheets'][i]['properties']['sheetId']:
+                    properties = sheet_data['sheets'][i]['properties']
+                    return Worksheet(self, properties)
+            raise WorksheetNotFound
+        except (KeyError):
+            return None
 
     def worksheets(self):
         """Returns a list of all :class:`worksheets <gspread.models.Worksheet>`

--- a/tests/test.py
+++ b/tests/test.py
@@ -297,6 +297,10 @@ class SpreadsheetTest(GspreadTest):
     def test_get_worksheet(self):
         sheet1 = self.spreadsheet.get_worksheet(0)
         self.assertTrue(isinstance(sheet1, gspread.Worksheet))
+    
+    def test_get_worksheet_by_id(self):
+        sheet1 = self.spreadsheet.get_worksheet_by_id(0)
+        self.assertTrue(isinstance(sheet1, gspread.Worksheet))
 
     def test_worksheet(self):
         sheet_title = 'Sheet1'


### PR DESCRIPTION
Enables the possibility to get the worksheet by it's Id. This approach could be more robust because the worksheets ids never changes and it´s really easy to get it from the URL by looking the for the "**gid**" parameter value

New method:
get_worksheet_by_id