### PR TITLE
Document dictionary credentials auth

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -103,6 +103,27 @@ that has been used for authentication prio to the gspread version 3.6:
 
     gc = gspread.authorize(credentials)
 
+There is also the option to pass credentials as a dictionary:
+
+::
+
+    import gspread
+    
+    credentials = {
+        "type": "service_account",
+        "project_id": "api-project-XXX",
+        "private_key_id": "2cd … ba4",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nNrDyLw … jINQh/9\n-----END PRIVATE KEY-----\n",
+        "client_email": "473000000000-yoursisdifferent@developer.gserviceaccount.com",
+        "client_id": "473 … hd.apps.googleusercontent.com",
+        ...
+    }
+
+    gc = gspread.service_account_from_dict(credentials)
+
+    sh = gc.open("Example spreadsheet")
+
+    print(sh.sheet1.get('A1'))
 
 .. NOTE::
    Older versions of gspread have used `oauth2client <https://github.com/google/oauth2client>`_. Google has


### PR DESCRIPTION
Hello,

the library provides two methods of auth: [service_account](https://github.com/dmytrostriletskyi/gspread/blob/master/gspread/auth.py#L158) and [service_account_from_dict](https://github.com/dmytrostriletskyi/gspread/blob/master/gspread/auth.py#L187). `service_account_from_dict` was added last year in [this pull request](https://github.com/burnash/gspread/pull/785), but wasn't documented. At least, I have not found anything:

<img width="993" alt="Screenshot 2021-04-16 at 12 07 46" src="https://user-images.githubusercontent.com/22666467/115001495-5c989880-9eac-11eb-98b6-7412e29b7b94.png">

So, this pull requests adds some documentation for the `service_account_from_dict` function to [auth using service account documentation section](https://gspread.readthedocs.io/en/latest/oauth2.html#for-bots-using-service-account). I have built it locally, it looks like:

<img width="1680" alt="Screenshot 2021-04-16 at 12 19 59" src="https://user-images.githubusercontent.com/22666467/115003153-3542cb00-9eae-11eb-8c0c-113465b5c9af.png">

If there is something I should add, just tell me. Thank you in advance! :)