### PR TITLE
Autocast numeric values to python int or float

### DIFF
--- a/gspread/models.py
+++ b/gspread/models.py
@@ -14,6 +14,7 @@ from .utils import (
     a1_to_rowcol,
     rowcol_to_a1,
     cast_to_a1_notation,
+    numericise,
     numericise_all,
     finditem,
     fill_gaps,
@@ -2117,9 +2118,12 @@ class Cell(object):
 
     @property
     def numeric_value(self):
-        try:
-            return float(self.value)
-        except ValueError:
+        numeric_value = numericise(self.value, default_blank=None)
+
+        # if could not convert, return None
+        if type(numeric_value) == int or type(numeric_value) == float:
+            return numeric_value
+        else:
             return None
 
     @property

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -121,6 +121,8 @@ def numericise(
     '32'
     >>> numericise("3.1")
     3.1
+    >>> numericise("2,000.1")
+    2000.1
     >>> numericise("", empty2zero=True)
     0
     >>> numericise("", empty2zero=False)
@@ -139,6 +141,9 @@ def numericise(
             if not allow_underscores_in_numeric_literals:
                 return value
             value = value.replace("_", "")
+
+        # replace coma separating thousands to match python format
+        value = value.replace(",", "")
         try:
             value = int(value)
         except ValueError:

--- a/tests/test.py
+++ b/tests/test.py
@@ -1173,6 +1173,15 @@ class CellTest(GspreadTest):
         cell = self.sheet.acell('A1')
         self.assertEqual(cell.numeric_value, numeric_value)
         self.assertTrue(isinstance(cell.numeric_value, float))
+
+        # test value for popular format with long numbers
+        numeric_value = 2000000.01
+        self.sheet.update_acell('A1', '2,000,000.01')
+        cell = self.sheet.acell('A1')
+        self.assertEqual(cell.numeric_value, numeric_value)
+        self.assertTrue(isinstance(cell.numeric_value, float))
+
+        # test non numeric value
         self.sheet.update_acell('A1', 'Non-numeric value')
         cell = self.sheet.acell('A1')
         self.assertEqual(cell.numeric_value, None)


### PR DESCRIPTION
When requesting the numeric value of a cell using `.numeric_value` benefit from the function
`numericise` to auto-cast to a python numeric value if possible.

Return None in case `ValueError` could not cast.

Update function `numericise` to convert spreadsheet number format `2,000,000.01`
to python convertible format => `2000000.01`.

Closes #132 

Signed-off-by: Alexandre Lavigne <lavigne958@gmail.com>