### PR TITLE
Improvement: Fetch SpreadSheet creation and lastUpdate time.

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -89,6 +89,7 @@ class Client(object):
             'pageSize': 1000,
             'supportsAllDrives': True,
             'includeItemsFromAllDrives': True,
+            'fields': 'kind,nextPageToken,files(id,name,createdTime,modifiedTime)',
         }
 
         while page_token is not None:

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -38,6 +38,7 @@ from .urls import (
     SPREADSHEET_VALUES_BATCH_UPDATE_URL,
     SPREADSHEET_SHEETS_COPY_TO_URL,
 )
+from gspread import utils
 
 try:
     unicode
@@ -102,6 +103,32 @@ class Spreadsheet(object):
     def url(self):
         """Spreadsheet URL."""
         return SPREADSHEET_DRIVE_URL % self.id
+
+    @property
+    def creationTime(self):
+        """Spreadsheet Creation time."""
+        try:
+            return self._properties['createdTime']
+        except KeyError:
+            # Filter the list using the name to reduce the request size
+            # Filter the item using the unique ID to ensure we update the exacte same item
+            metadata = utils.finditem(lambda x: x["id"] == self.id,
+                                    self.client.list_spreadsheet_files(self.title))
+            self._properties.update(metadata)
+            return self._properties['createdTime']
+
+    @property
+    def lastUpdateTime(self):
+        """Spreadsheet Creation time."""
+        try:
+            return self._properties['modifiedTime']
+        except KeyError:
+            # Filter the list using the name to reduce the request size
+            # Filter the item using the unique ID to ensure we update the exacte same item
+            metadata = utils.finditem(lambda x: x["id"] == self.id,
+                                    self.client.list_spreadsheet_files(self.title))
+            self._properties.update(metadata)
+            return self._properties['modifiedTime']
 
     @property
     def updated(self):


### PR DESCRIPTION
On a call to `open` or `openall` methods we use the GoogleDrive API,
set the list of fields to retrieve and retrieve `createdTime` and `modifiedTime`.
This allows us to get the creation and last modified time of a SpreadSheet.

When using `open_by_key` or `open_by_url` we do not use the GoogleDrive API,
this prevent us from accessing this informaiton, if a user tries to access the `creationTime` or
`lastUpdateTime` property of a SpreadSheet then query the GoogleDrive API to get it.

Benefit from that call to update SpreadSheet metadata on the way.

Closes #332

Signed-off-by: Alexandre Lavigne <lavigne958@gmail.com>