### PR TITLE
Bug-fix - use Makefile to run tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,12 +29,12 @@ pip install -r test-requirements.txt
 3. Run tests:
 
 ```
-GS_CREDS_FILENAME=<YOUR_CREDS.json> nosetests -vv tests/test.py
+GS_CREDS_FILENAME=<YOUR_CREDS.json> make test
 ```
 
 where `YOUR_CREDS.json` is a path to the file you downloaded in step 1.
 
-**Tip:** To run a specific test method append its name in the form of `:TestClassName.test_method_name` to `tests/test.py`.
+**Tip:** To run a specific test method you must use the full command and append the test method name in the form of `:TestClassName.test_method_name` to `tests/test.py`.
 
 Example:
 
@@ -46,7 +46,7 @@ GS_CREDS_FILENAME=<YOUR_CREDS.json> nosetests -vv tests/test.py:WorksheetTest.te
 You can control Betamax's [Record Mode](https://betamax.readthedocs.io/en/latest/record_modes.html) using `GS_RECORD_MODE` environment variable:
 
 ```
-GS_RECORD_MODE=all GS_CREDS_FILENAME=<YOUR_CREDS.json> nosetests -vv tests/test.py
+GS_RECORD_MODE=all GS_CREDS_FILENAME=<YOUR_CREDS.json> make test
 ```
 
 ## Render Documentation

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 envlist = py27,py34,py35,py36
 
 [testenv]
+passenv = GS_RECORD_MODE GS_CREDS_FILENAME
 deps = -rtest-requirements.txt
 commands = nosetests -vv tests/test.py


### PR DESCRIPTION
In order to run the test suite with the command `make test` tox must
pass the env variables to `nosetests`.

the following env variables are so far the only variables necessary to run the tests
- GS_RECORD_MODE: to change the recoding mode
- GS_CREDS_FILENAME: to specify you credentials to reach google API

closes #878 