### PR TITLE
store creds correctly when authorized_user_filename is passed to gspread.auth.oauth()

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -163,7 +163,7 @@ def oauth(
 
     if not creds:
         creds = flow(scopes=scopes)
-        store_credentials(creds)
+        store_credentials(creds, filename=authorized_user_filename)
 
     client = Client(auth=creds)
     return client


### PR DESCRIPTION
# Summary

#847 allows users to use custom path for authorized user credentials.

With current implementation, when I call `gspread.auth.oauth()` with custom path,
`oauth()` reads credentials from the given path correctly, but if credentials file is missing,
it authorizes user and store the credentials to the default path (`~/.config/gspread/credentials.json`),
not the custom path!

According to the docs, this behavior is incorrect:
https://github.com/burnash/gspread/blob/master/docs/oauth2.rst

> If you want to store the credentials file somewhere else, specify the path to `authorized_user.json`

This PR fixes `store_credentials()` in `gspread.auth.oauth()` to store creds correctly when `authorized_user_filename` is passed to  `gspread.auth.oauth()`.
