### PR TITLE
Improvement - allow creation of spreadsheets in shared drives

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -191,10 +191,14 @@ class Client(object):
             'mimeType': 'application/vnd.google-apps.spreadsheet',
         }
 
+        params = {
+            "supportsAllDrives": True,
+        }
+
         if folder_id is not None:
             payload['parents'] = [folder_id]
 
-        r = self.request('post', DRIVE_FILES_API_V3_URL, json=payload)
+        r = self.request('post', DRIVE_FILES_API_V3_URL, json=payload, params=params)
         spreadsheet_id = r.json()['id']
         return self.open_by_key(spreadsheet_id)
 


### PR DESCRIPTION
If the `folder_id` is located in a shared drive, this parameter
must be `True` for the API to find the folder.

This does not have any effect in regular drives, keep it
set to `True`.

duplicate of #865 
closes #778 