### PR TITLE
Fix client.copy copy_permission argument compare

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -251,7 +251,7 @@ class Client(object):
 
         new_spreadsheet = self.open_by_key(spreadsheet_id)
 
-        if copy_permissions:
+        if copy_permissions is True:
             original = self.open_by_key(file_id)
 
             permissions = original.list_permissions()


### PR DESCRIPTION
When comparing value in `if` statement, when that value
should be a boolean use `if value is True :` instead of `if value :`
because any type of variable/object would meet the `True` condition
in the second case but only `True` would meet the `True` condition
on the first case.

In the case of `copy_permission` we expect a boolean of value `True`
only.

closes #892