### PR TITLE
find method return none

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -199,6 +199,7 @@ Find a cell matching a regular expression
    amount_re = re.compile(r'(Big|Enormous) dough')
    cell = worksheet.find(amount_re)
 
+`find` returns `None` if value is not Found
 
 Finding All Matched Cells
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1977,7 +1977,7 @@ class Worksheet(object):
         try:
             return self._finder(finditem, query, in_row, in_column)
         except StopIteration:
-            raise CellNotFound(query)
+            return None
 
     def findall(self, query, in_row=None, in_column=None):
         """Finds all cells matching the query.

--- a/gspread/models.py
+++ b/gspread/models.py
@@ -1973,6 +1973,7 @@ class Worksheet(object):
         :param int in_row: (optional) One-based row number to scope the search.
         :param int in_column: (optional) One-based column number to scope
             the search.
+        :returns: the first matching cell or None otherwise
         """
         try:
             return self._finder(finditem, query, in_row, in_column)

--- a/tests/test.py
+++ b/tests/test.py
@@ -720,6 +720,9 @@ class WorksheetTest(GspreadTest):
         cell = self.sheet.find(o_O_re)
         self.assertEqual(cell.value, value)
 
+        not_found = self.sheet.find("does not exists")
+        self.assertIs(not_found, None, "find should return 'None' when value is not found")
+
     def test_findall(self):
         list_len = 10
         range_label = 'A1:A%s' % list_len


### PR DESCRIPTION
based on previous PR #790  from @GastonBC.

`find` method should return `None` in case of no matching cell.

This would make it more user-friendly to use.

Instead of sample code like:

```python
try:
    cell = worksheet.find(query)
except CellNotFound as e:
    cell = None
    # do something
# do something with cell, possibly:
if cell is None:
    # handle not found cell
```

We could simply have:

```python
cell = worksheet.find(query)
if cell is None:
    # handle not found cell
```

this is motivated by the fact that the result of `find` is used and (possibly) checked returning `None` makes more sense as the user would check the value and try to access it.

Thanks @GastonBC for original PR