### PR TITLE
Add more flake8 tests

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -15,8 +15,8 @@ jobs:
       - run: bandit --recursive --skip B105,B110,B311,B605,B607 .
       - run: black --check .
       - run: codespell  # --ignore-words-list="" --skip=""
-      - run: flake8 --ignore=E12,E20,E226,E231,E265,E271,E40,E731,F401,W29,W605
-                    --max-complexity=10 --max-line-length=255 --show-source --statistics .
+      - run: flake8 --ignore=E203 --max-complexity=10 --max-line-length=255
+                    --show-source --statistics .
       - run: isort --check-only --profile black .
       - run: pip install -r test-requirements.txt
       - run: tox -e py || true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,7 @@ from datetime import date
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-import gspread
-from gspread import __version__
+from gspread import __version__  # noqa: E402
 
 # -- General configuration -----------------------------------------------------
 
@@ -183,11 +182,11 @@ htmlhelp_basename = "gspreaddoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    # 'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+# flake8: noqa
+
 """
 gspread
 ~~~~~~~

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -28,7 +28,7 @@ READONLY_SCOPES = [
 
 
 def get_config_dir(config_dir_name="gspread", os_is_windows=os.name == "nt"):
-    """Construct a config dir path.
+    r"""Construct a config dir path.
 
     By default:
         * `%APPDATA%\gspread` on Windows
@@ -96,7 +96,7 @@ def oauth(
     credentials_filename=DEFAULT_CREDENTIALS_FILENAME,
     authorized_user_filename=DEFAULT_AUTHORIZED_USER_FILENAME,
 ):
-    """Authenticate with OAuth Client ID.
+    r"""Authenticate with OAuth Client ID.
 
     By default this function will use the local server strategy and open
     the authorization URL in the user’s browser::

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -9,7 +9,6 @@ This module contains utility functions.
 """
 
 import re
-import sys
 from collections import defaultdict
 from functools import wraps
 

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1371,9 +1371,14 @@ class Worksheet(object):
         cells = self._list_cells(values, in_row, in_column)
 
         if isinstance(query, str):
-            match = lambda x: x.value == query
+
+            def match(x):
+                return x.value == query
+
         else:
-            match = lambda x: query.search(x.value)
+
+            def match(x):
+                return query.search(x.value)
 
         return func(match, cells)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import gspread
-import gspread.utils as utils
-from gspread.exceptions import APIError
 
 from .test import GspreadTest
 
@@ -61,7 +59,7 @@ class ClientTest(GspreadTest):
 
     def test_access_non_existing_spreadsheet(self):
         wks = self.gc.open_by_key("test")
-        with self.assertRaises(APIError) as error:
+        with self.assertRaises(gspread.exceptions.APIError) as error:
             wks.worksheets()
         self.assertEqual(error.exception.args[0]["code"], 404)
         self.assertEqual(


### PR DESCRIPTION
Now that we have run `black` and `isort`, most flake8 tests pass.

This PR makes minor changes so that flake8 tests all pass except one that is incompatible with black.
* https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8