### PR TITLE
Improvement - Add `Worksheet.index` property

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -88,6 +88,11 @@ class Worksheet:
         return WORKSHEET_DRIVE_URL % (self.spreadsheet.id, self.id)
 
     @property
+    def index(self):
+        """Worksheet index."""
+        return self._properties["index"]
+
+    @property
     def updated(self):
         """.. deprecated:: 2.0
 


### PR DESCRIPTION
Expose worksheet index property.

closes #804 