### PR TITLE
Create default config directory if not exists

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -84,6 +84,7 @@ def load_credentials(filename=DEFAULT_AUTHORIZED_USER_FILENAME):
 
 
 def store_credentials(creds, filename=DEFAULT_AUTHORIZED_USER_FILENAME, strip="token"):
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, "w") as f:
         f.write(creds.to_json(strip))
 


### PR DESCRIPTION
In store_credentials function, create the DEFAULT_CONFIG_DIR defined from the get_config_dir() function if it doesn't currently exist.