### PR TITLE
Update the link to the Google Developers Console

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -11,7 +11,7 @@ To access spreadsheets via Google Sheets API you need to authenticate and author
 Enable API Access for a Project
 -------------------------------
 
-1. Head to `Google Developers Console <https://console.developers.google.com/project>`_ and create a new project (or select the one you already have).
+1. Head to `Google Developers Console <https://console.developers.google.com/>`_ and create a new project (or select the one you already have).
 
 2. In the box labeled "Search for APIs and Services", search for "Google Drive API" and enable it.
 


### PR DESCRIPTION
Currently, the link in the documentation on https://docs.gspread.org/en/latest/oauth2.html#using-signed-credentials links to:

https://console.cloud.google.com/project

However, that link gives you the following error:
> There is a temporary block on your account. This happens when Google detects requests from your network that may have been sent by malicious software, a browser plug-in, or script that sends automated requests.
>Retry in a few minutes.

By removing the `/project` from the URL, the link works and allows users to properly get to the console.