### PR TITLE
Bugfix/fix protected range user emails list

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1206,14 +1206,21 @@ class Worksheet:
     def add_protected_range(
         self,
         name,
-        editor_users_emails=[],
+        editor_users_emails,
         editor_groups_emails=[],
         description=None,
         warning_only=False,
         requesting_user_can_edit=False,
     ):
-        """ "Add protected range to the sheet. Only the editors can edit
+        """Add protected range to the sheet. Only the editors can edit
         the protected range.
+
+        Google API will automatically add the owner of this SpreadSheet.
+        The list ``editor_users_emails`` must at least contain the e-mail
+        address used to open that SpreadSheet.
+
+        ``editor_users_emails`` must only contain e-mail addresses
+        who already have a write access to the spreadsheet.
 
         :param str name: A string with range value in A1 notation,
             e.g. 'A1:A5'.
@@ -1228,8 +1235,9 @@ class Worksheet:
 
         For both A1 and numeric notation:
 
-        :param list editor_users_emails: (optional) The email addresses of
+        :param list editor_users_emails: The email addresses of
             users with edit access to the protected range.
+            This must include your e-mail address at least.
         :param list editor_groups_emails: (optional) The email addresses of
             groups with edit access to the protected range.
         :param str description: (optional) Description for the protected


### PR DESCRIPTION
## Bug description

current implementation adds all the email addresses with any kind of access (read, write) as editor of a protected range.

A protected range is a range where only a subset of the email addresses with a write access can edit.

## Bugfix

simply add any given email address from the user, if the address does not have write access, if the address does not exists, etc this is in charge of the user to handle.
Update docstring for the user to clearly understand what is expected and any side effects.