### PR TITLE
add shadow method to get a named range from a speadsheet instance.

### DIFF
--- a/gspread/spreadsheet.py
+++ b/gspread/spreadsheet.py
@@ -546,3 +546,15 @@ class Spreadsheet:
             self.client.remove_permission(self.id, permission_id)
 
         return filtered_id_list
+
+    def named_range(self, named_range):
+        """return a list of :class:`Cell` objects from
+        the specified named range.
+
+        :param name: A string with a named range value to fecth.
+        :type name: str
+        """
+
+        # the function `range` does all necessary actions to get a named range.
+        # This is only here to provide better user experience.
+        return self.sheet1.range(named_range)


### PR DESCRIPTION
This is only a shadow method that calls the underlying method
located in the worksheet instance.

The method `worksheet.range` does all the necessary actions to fetch
and clean the resulting values to get a named range.

closes #876 