### PR TITLE
fix fully qualified class names in API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,19 +19,19 @@ Client
 Models
 ------
 
-The models represent common spreadsheet entities: :class:`a spreadsheet <gspread.models.Spreadsheet>`,
-:class:`a worksheet <gspread.models.Worksheet>` and :class:`a cell <gspread.models.Cell>`.
+The models represent common spreadsheet entities: :class:`a spreadsheet <gspread.spreadsheet.Spreadsheet>`,
+:class:`a worksheet <gspread.worksheet.Worksheet>` and :class:`a cell <gspread.cell.Cell>`.
 
 .. note::
 
    The classes described below should not be instantiated by the end-user. Their
    instances result from calling other objects' methods.
 
-.. autoclass:: gspread.models.Spreadsheet
+.. autoclass:: gspread.spreadsheet.Spreadsheet
    :members:
-.. autoclass:: gspread.models.Worksheet
+.. autoclass:: gspread.worksheet.Worksheet
    :members:
-.. autoclass:: gspread.models.Cell
+.. autoclass:: gspread.cell.Cell
    :members:
 
 Utils


### PR DESCRIPTION
Spreadsheet, Worksheet and Cell have moved from `models.py` into their own source files. This references them in their new source files and allows the `autoclass` documentation to be generated once again