### PR TITLE
Replace raw string used in function arguments (Dimension, ValueRenderOption)

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -36,6 +36,9 @@ Dimension = namedtuple("_Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
 ValueRenderOption = namedtuple(
     "_ValueRenderOption", ["formatted", "unformatted", "formula"]
 )("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
+ValueInputOption = namedtuple(
+    "_ValueInputOption", ["raw", "user_entered"]
+)("RAW", "USER_ENTERED")
 
 
 def convert_credentials(credentials):
@@ -354,7 +357,8 @@ def a1_range_to_grid_range(name, sheet_id=None):
 
     start_row_index, start_column_index = _a1_to_rowcol_unbounded(start_label)
 
-    end_row_index, end_column_index = _a1_to_rowcol_unbounded(end_label or start_label)
+    end_row_index, end_column_index = _a1_to_rowcol_unbounded(
+        end_label or start_label)
 
     if start_row_index > end_row_index:
         start_row_index, end_row_index = end_row_index, start_row_index
@@ -369,7 +373,12 @@ def a1_range_to_grid_range(name, sheet_id=None):
         "endColumnIndex": end_column_index,
     }
 
-    grid_range = {key: value for (key, value) in grid_range.items() if value != inf}
+    grid_range = {
+        key: value
+        for (key, value)
+        in grid_range.items()
+        if value != inf
+    }
 
     if sheet_id is not None:
         grid_range["sheetId"] = sheet_id

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -36,9 +36,9 @@ Dimension = namedtuple("_Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
 ValueRenderOption = namedtuple(
     "_ValueRenderOption", ["formatted", "unformatted", "formula"]
 )("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
-ValueInputOption = namedtuple(
-    "_ValueInputOption", ["raw", "user_entered"]
-)("RAW", "USER_ENTERED")
+ValueInputOption = namedtuple("_ValueInputOption", ["raw", "user_entered"])(
+    "RAW", "USER_ENTERED"
+)
 
 
 def convert_credentials(credentials):
@@ -357,8 +357,7 @@ def a1_range_to_grid_range(name, sheet_id=None):
 
     start_row_index, start_column_index = _a1_to_rowcol_unbounded(start_label)
 
-    end_row_index, end_column_index = _a1_to_rowcol_unbounded(
-        end_label or start_label)
+    end_row_index, end_column_index = _a1_to_rowcol_unbounded(end_label or start_label)
 
     if start_row_index > end_row_index:
         start_row_index, end_row_index = end_row_index, start_row_index
@@ -373,12 +372,7 @@ def a1_range_to_grid_range(name, sheet_id=None):
         "endColumnIndex": end_column_index,
     }
 
-    grid_range = {
-        key: value
-        for (key, value)
-        in grid_range.items()
-        if value != inf
-    }
+    grid_range = {key: value for (key, value) in grid_range.items() if value != inf}
 
     if sheet_id is not None:
         grid_range["sheetId"] = sheet_id

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -7,7 +7,7 @@ This module contains utility functions.
 """
 
 import re
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from functools import wraps
 from math import inf
 
@@ -31,6 +31,11 @@ A1_ADDR_ROW_COL_RE = re.compile(r"([A-Za-z]+)?([1-9]\d*)?$")
 
 URL_KEY_V1_RE = re.compile(r"key=([^&#]+)")
 URL_KEY_V2_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9-_]+)")
+
+Dimension = namedtuple("_Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
+ValueRenderOption = namedtuple(
+    "_ValueRenderOption", ["formatted", "unformatted", "formula"]
+)("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
 
 
 def convert_credentials(credentials):

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -6,10 +6,11 @@ This module contains common worksheets' models.
 
 """
 
-from collections import namedtuple
 from .cell import Cell
 from .urls import SPREADSHEET_URL, WORKSHEET_DRIVE_URL
 from .utils import (
+    Dimension,
+    ValueRenderOption,
     a1_range_to_grid_range,
     a1_to_rowcol,
     absolute_range_name,
@@ -23,12 +24,6 @@ from .utils import (
     numericise_all,
     rowcol_to_a1,
 )
-
-Dimension = namedtuple('_Dimension', ['rows', 'cols'])('ROWS', 'COLUMNS')
-ValueRenderOption = namedtuple(
-    '_ValueRenderOption',
-    ['formatted', 'unformatted', 'formula']
-)('FORMATTED_VALUE', 'UNFORMATTED_VALUE', 'FORMULA')
 
 
 class ValueRange(list):
@@ -143,7 +138,7 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+        :type value_render_option:  ( `ValueRenderOption.formatted` |
                                     `ValueRenderOption.unformatted` |
                                     `ValueRenderOption.formula` )
 
@@ -169,7 +164,7 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+        :type value_render_option:  ( `ValueRenderOption.formatted` |
                                     `ValueRenderOption.unformatted` |
                                     `ValueRenderOption.formula` )
 
@@ -273,7 +268,7 @@ class Worksheet:
             non empty cells.
 
         :param str major_dimension: (optional) The major dimension of the
-            values. `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS"). Defaults to Dimension.rows 
+            values. `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS"). Defaults to Dimension.rows
 
         :param str value_render_option: (optional) Determines how values should
             be rendered in the the output. See `ValueRenderOption`_ in
@@ -462,7 +457,7 @@ class Worksheet:
             range_name,
             params={
                 "valueRenderOption": value_render_option,
-                "majorDimension":  Dimension.cols,
+                "majorDimension": Dimension.cols,
             },
         )
 

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -25,6 +25,10 @@ from .utils import (
 )
 
 Dimension = namedtuple('_Dimension', ['rows', 'cols'])('ROWS', 'COLUMNS')
+ValueRenderOption = namedtuple(
+    '_ValueRenderOption',
+    ['formatted', 'unformatted', 'formula']
+)('FORMATTED_VALUE', 'UNFORMATTED_VALUE', 'FORMULA')
 
 
 class ValueRange(list):
@@ -130,7 +134,7 @@ class Worksheet:
         """Number of frozen columns."""
         return self._properties["gridProperties"].get("frozenColumnCount", 0)
 
-    def acell(self, label, value_render_option="FORMATTED_VALUE"):
+    def acell(self, label, value_render_option=ValueRenderOption.formatted):
         """Returns an instance of a :class:`gspread.models.Cell`.
 
         :param label: Cell label in A1 notation
@@ -139,7 +143,9 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option: str
+        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+                                    `ValueRenderOption.unformatted` |
+                                    `ValueRenderOption.formula` )
 
         .. _ValueRenderOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption
 
@@ -152,7 +158,7 @@ class Worksheet:
             *(a1_to_rowcol(label)), value_render_option=value_render_option
         )
 
-    def cell(self, row, col, value_render_option="FORMATTED_VALUE"):
+    def cell(self, row, col, value_render_option=ValueRenderOption.formatted):
         """Returns an instance of a :class:`gspread.models.Cell` located at
         `row` and `col` column.
 
@@ -163,7 +169,9 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option: str
+        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+                                    `ValueRenderOption.unformatted` |
+                                    `ValueRenderOption.formula` )
 
         .. _ValueRenderOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption
 
@@ -273,17 +281,17 @@ class Worksheet:
 
             Possible values are:
 
-            ``FORMATTED_VALUE``
+            ``ValueRenderOption.formatted``
                 (default) Values will be calculated and formatted according
                 to the cell's formatting. Formatting is based on the
                 spreadsheet's locale, not the requesting user's locale.
 
-            ``UNFORMATTED_VALUE``
+            ``ValueRenderOption.unformatted``
                 Values will be calculated, but not formatted in the reply.
                 For example, if A1 is 1.23 and A2 is =A1 and formatted as
                 currency, then A2 would return the number 1.23.
 
-            ``FORMULA``
+            ``ValueRenderOption.formula``
                 Values will not be calculated. The reply will include
                 the formulas. For example, if A1 is 1.23 and A2 is =A1 and
                 formatted as currency, then A2 would return "=A1".
@@ -292,8 +300,8 @@ class Worksheet:
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            ``value_render_option`` is ``FORMATTED_VALUE``. The default
-            ``date_time_render_option`` is ``SERIAL_NUMBER``.
+            ``value_render_option`` is ``ValueRenderOption.formatted``.
+            The default ``date_time_render_option`` is ``SERIAL_NUMBER``.
 
         .. note::
 
@@ -314,10 +322,10 @@ class Worksheet:
             worksheet.get_values('my_range')
 
             # Return unformatted values (e.g. numbers as numbers)
-            worksheet.get_values('A2:B4', value_render_option='UNFORMATTED_VALUE')
+            worksheet.get_values('A2:B4', value_render_option=ValueRenderOption.unformatted)
 
             # Return cell values without calculating formulas
-            worksheet.get_values('A2:B4', value_render_option='FORMULA')
+            worksheet.get_values('A2:B4', value_render_option=ValueRenderOption.formula)
         """
         try:
             return fill_gaps(self.get(range_name, **kwargs))
@@ -432,7 +440,7 @@ class Worksheet:
         except KeyError:
             return []
 
-    def col_values(self, col, value_render_option="FORMATTED_VALUE"):
+    def col_values(self, col, value_render_option=ValueRenderOption.formatted):
         """Returns a list of all values in column `col`.
 
         Empty cells in this list will be rendered as :const:`None`.
@@ -562,11 +570,11 @@ class Worksheet:
 
         :param str value_render_option: (optional) How values should be
             represented in the output. The default render option is
-            ``FORMATTED_VALUE``.
+            ``ValueRenderOption.formatted``.
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            ``value_render_option`` is ``FORMATTED_VALUE``. The default
+            ``value_render_option`` is ``ValueRenderOption.formatted``. The default
             ``date_time_render_option`` is ``SERIAL_NUMBER``.
 
         Examples::
@@ -615,11 +623,11 @@ class Worksheet:
 
         :param str value_render_option: (optional) How values should be
             represented in the output. The default render option
-            is ``FORMATTED_VALUE``.
+            is ``ValueRenderOption.formatted``.
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            value_render_option is ``FORMATTED_VALUE``. The default dateTime
+            value_render_option is ``ValueRenderOption.formatted``. The default dateTime
             render option is ``SERIAL_NUMBER``.
 
         .. versionadded:: 3.3

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -462,7 +462,7 @@ class Worksheet:
             range_name,
             params={
                 "valueRenderOption": value_render_option,
-                "majorDimension": "COLUMNS",
+                "majorDimension":  Dimension.cols,
             },
         )
 
@@ -1033,7 +1033,7 @@ class Worksheet:
                     "autoResizeDimensions": {
                         "dimensions": {
                             "sheetId": self.id,
-                            "dimension": "COLUMNS",
+                            "dimension": Dimension.cols,
                             "startIndex": int(start_column_index),
                             "endIndex": int(end_column_index),
                         }
@@ -1166,7 +1166,7 @@ class Worksheet:
                     "insertDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": "ROWS",
+                            "dimension": Dimension.rows,
                             "startIndex": row - 1,
                             "endIndex": len(values) + row - 1,
                         }
@@ -1181,7 +1181,7 @@ class Worksheet:
 
         params = {"valueInputOption": value_input_option}
 
-        body = {"majorDimension": "ROWS", "values": values}
+        body = {"majorDimension": Dimension.rows, "values": values}
 
         return self.spreadsheet.values_append(range_label, params, body)
 
@@ -1203,7 +1203,7 @@ class Worksheet:
                     "insertDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": "COLUMNS",
+                            "dimension": Dimension.cols,
                             "startIndex": col - 1,
                             "endIndex": len(values) + col - 1,
                         }
@@ -1218,7 +1218,7 @@ class Worksheet:
 
         params = {"valueInputOption": value_input_option}
 
-        body = {"majorDimension": "COLUMNS", "values": values}
+        body = {"majorDimension": Dimension.cols, "values": values}
 
         return self.spreadsheet.values_append(range_label, params, body)
 
@@ -1355,7 +1355,7 @@ class Worksheet:
             worksheet.delete_rows(2)
 
         """
-        return self.delete_dimension("ROWS", start_index, end_index)
+        return self.delete_dimension(Dimension.rows, start_index, end_index)
 
     def delete_columns(self, start_index, end_index=None):
         """Deletes multiple columns from the worksheet at the specified index.
@@ -1365,7 +1365,7 @@ class Worksheet:
             When end_index is not specified this method only deletes a single
             column at ``start_index``.
         """
-        return self.delete_dimension("COLUMNS", start_index, end_index)
+        return self.delete_dimension(Dimension.cols, start_index, end_index)
 
     def clear(self):
         """Clears all cells in the worksheet."""

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -6,6 +6,7 @@ This module contains common worksheets' models.
 
 """
 
+from collections import namedtuple
 from .cell import Cell
 from .urls import SPREADSHEET_URL, WORKSHEET_DRIVE_URL
 from .utils import (
@@ -22,6 +23,8 @@ from .utils import (
     numericise_all,
     rowcol_to_a1,
 )
+
+Dimension = namedtuple('_Dimension', ['rows', 'cols'])('ROWS', 'COLUMNS')
 
 
 class ValueRange(list):
@@ -262,7 +265,7 @@ class Worksheet:
             non empty cells.
 
         :param str major_dimension: (optional) The major dimension of the
-            values. Either ``ROWS`` or ``COLUMNS``. Defaults to ``ROWS``
+            values. `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS"). Defaults to Dimension.rows 
 
         :param str value_render_option: (optional) Determines how values should
             be rendered in the the output. See `ValueRenderOption`_ in
@@ -554,8 +557,8 @@ class Worksheet:
         :param str range_name: (optional) Cell range in the A1 notation or
             a named range.
 
-        :param str major_dimension: (optional) The major dimension that results
-            should use. Either ``ROWS`` or ``COLUMNS``.
+        :param str major_dimension: (optional) The major dimension that results should use.
+            Either `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS").
 
         :param str value_render_option: (optional) How values should be
             represented in the output. The default render option is
@@ -607,8 +610,8 @@ class Worksheet:
         :param list ranges: List of cell ranges in the A1 notation or named
             ranges.
 
-        :param str major_dimension: (optional) The major dimension that results
-            should use. Either ``ROWS`` or ``COLUMNS``.
+        :param str major_dimension: (optional) The major dimension that results should use.
+            Either `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS").
 
         :param str value_render_option: (optional) How values should be
             represented in the output. The default render option
@@ -660,8 +663,8 @@ class Worksheet:
             strings. Defaults to ``True``. This is a shortcut for
             the ``value_input_option`` parameter.
 
-        :param str major_dimension: (optional) The major dimension of the
-            values. Either ``ROWS`` or ``COLUMNS``.
+        :param str major_dimension: (optional) The major dimension of the values.
+            Either `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS").
 
         :param str value_input_option: (optional) How the input data should be
             interpreted. Possible values are:

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -248,8 +248,7 @@ class Worksheet:
         )
 
         return [
-            Cell(row=i + row_offset + 1, col=j +
-                 column_offset + 1, value=value)
+            Cell(row=i + row_offset + 1, col=j + column_offset + 1, value=value)
             for i, row in enumerate(rect_values)
             for j, value in enumerate(row)
         ]
@@ -399,7 +398,7 @@ class Worksheet:
         keys = data[idx]
 
         if numericise_ignore == ["all"]:
-            values = data[idx + 1:]
+            values = data[idx + 1 :]
         else:
             values = [
                 numericise_all(
@@ -409,7 +408,7 @@ class Worksheet:
                     allow_underscores_in_numeric_literals,
                     numericise_ignore,
                 )
-                for row in data[idx + 1:]
+                for row in data[idx + 1 :]
             ]
 
         return [dict(zip(keys, row)) for row in values]
@@ -539,11 +538,9 @@ class Worksheet:
         start = rowcol_to_a1(
             min(c.row for c in cell_list), min(c.col for c in cell_list)
         )
-        end = rowcol_to_a1(max(c.row for c in cell_list),
-                           max(c.col for c in cell_list))
+        end = rowcol_to_a1(max(c.row for c in cell_list), max(c.col for c in cell_list))
 
-        range_name = absolute_range_name(
-            self.title, "{}:{}".format(start, end))
+        range_name = absolute_range_name(self.title, "{}:{}".format(start, end))
 
         data = self.spreadsheet.values_update(
             range_name,
@@ -646,8 +643,7 @@ class Worksheet:
             }
         )
 
-        response = self.spreadsheet.values_batch_get(
-            ranges=ranges, params=params)
+        response = self.spreadsheet.values_batch_get(ranges=ranges, params=params)
 
         return [ValueRange.from_json(x) for x in response["valueRanges"]]
 
@@ -888,8 +884,7 @@ class Worksheet:
         if not grid_properties:
             raise TypeError("Either 'rows' or 'cols' should be specified.")
 
-        fields = ",".join("gridProperties/%s" %
-                          p for p in grid_properties.keys())
+        fields = ",".join("gridProperties/%s" % p for p in grid_properties.keys())
 
         body = {
             "requests": [
@@ -936,8 +931,7 @@ class Worksheet:
             start_row, start_col = a1_to_rowcol(start_a1)
             end_row, end_col = a1_to_rowcol(end_a1)
         else:
-            start_row = self._properties["gridProperties"].get(
-                "frozenRowCount", 0) + 1
+            start_row = self._properties["gridProperties"].get("frozenRowCount", 0) + 1
             start_col = 1
             end_row = self.row_count
             end_col = self.col_count
@@ -1432,8 +1426,7 @@ class Worksheet:
         ``in_row``` or ``in_column`` values (both one-based).
         """
         if in_row and in_column:
-            raise TypeError(
-                "Either 'in_row' or 'in_column' should be specified.")
+            raise TypeError("Either 'in_row' or 'in_column' should be specified.")
 
         if in_column:
             return [
@@ -1495,8 +1488,7 @@ class Worksheet:
         if not grid_properties:
             raise TypeError("Either 'rows' or 'cols' should be specified.")
 
-        fields = ",".join("gridProperties/%s" %
-                          p for p in grid_properties.keys())
+        fields = ",".join("gridProperties/%s" % p for p in grid_properties.keys())
 
         body = {
             "requests": [
@@ -1538,8 +1530,7 @@ class Worksheet:
             else {"sheetId": self.id}
         )
 
-        body = {"requests": [
-            {"setBasicFilter": {"filter": {"range": grid_range}}}]}
+        body = {"requests": [{"setBasicFilter": {"filter": {"range": grid_range}}}]}
 
         return self.spreadsheet.batch_update(body)
 
@@ -1651,8 +1642,7 @@ class Worksheet:
         """
         absolute_cell = absolute_range_name(self.title, cell)
         url = SPREADSHEET_URL % (self.spreadsheet.id)
-        params = {"ranges": absolute_cell,
-                  "fields": "sheets/data/rowData/values/note"}
+        params = {"ranges": absolute_cell, "fields": "sheets/data/rowData/values/note"}
         response = self.client.request("get", url, params=params)
         response.raise_for_status()
         response_json = response.json()

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -560,7 +560,9 @@ class WorksheetTest(GspreadTest):
         cell_list = self.sheet.range("A1:D2")
         for cell, value in zip(cell_list, itertools.chain(*rows)):
             cell.value = value
-        self.sheet.update_cells(cell_list, value_input_option="USER_ENTERED")
+        self.sheet.update_cells(
+            cell_list, value_input_option=utils.ValueInputOption.user_entered
+        )
 
         # default, formatted read
         read_records = self.sheet.get_all_records()
@@ -571,7 +573,7 @@ class WorksheetTest(GspreadTest):
 
         # unformatted read
         read_records = self.sheet.get_all_records(
-            value_render_option="UNFORMATTED_VALUE"
+            value_render_option=utils.ValueRenderOption.unformatted
         )
         expected_keys = [2, 43831, "string", 53]
         expected_values = [3 / 2, 0.12, 36162, ""]
@@ -579,7 +581,9 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(read_records[0], d0)
 
         # formula read
-        read_records = self.sheet.get_all_records(value_render_option="FORMULA")
+        read_records = self.sheet.get_all_records(
+            value_render_option=utils.ValueRenderOption.formula
+        )
         expected_keys = ["=4/2", 43831, "string", 53]
         expected_values = ["=3/2", 0.12, 36162, ""]
         d0 = dict(zip(expected_keys, expected_values))
@@ -596,12 +600,14 @@ class WorksheetTest(GspreadTest):
         cell_list = self.sheet.range("A1:D2")
         for cell, value in zip(cell_list, itertools.chain(*rows)):
             cell.value = value
-        self.sheet.update_cells(cell_list, value_input_option="USER_ENTERED")
+        self.sheet.update_cells(
+            cell_list, value_input_option=utils.ValueInputOption.user_entered
+        )
 
         read_records = self.sheet.get_all_records(
             default_blank="empty",
             allow_underscores_in_numeric_literals=True,
-            value_render_option="UNFORMATTED_VALUE",
+            value_render_option=utils.ValueRenderOption.unformatted,
         )
         expected_values = [3 / 2, 0.12, "empty", 321]
         d0 = dict(zip(rows[0], expected_values))
@@ -664,7 +670,7 @@ class WorksheetTest(GspreadTest):
         self.sheet.update_acell("B2", formula)
         values = [next(sg) for i in range(num_cols + 4)]
         self.sheet.insert_row(values, 1)
-        b3 = self.sheet.acell("B3", value_render_option="FORMULA")
+        b3 = self.sheet.acell("B3", value_render_option=utils.ValueRenderOption.formula)
         self.assertEqual(b3.value, formula)
 
     @pytest.mark.vcr()


### PR DESCRIPTION
Dimensions and ValueRenderOptions were used by strings,

replacing those, that are not likely to change at future, to accessible instance would make users more comfortable

`dataclass`  was the first and most suitable solution I thought, but it was added in [version 3.7](https://www.python.org/dev/peps/pep-0557/)

Usage will be like

```python
ws = spreadSheet.worksheet('test')

# current

ws.get_values(
    "A1:B5",
    major_dimension="ROWS",
    value_render_option="FORMATTED_VALUE"
)

# future
ws.get_values(
    "A1:B5",
    major_dimension=Dimension.rows,
    value_render_option= ValueRenderOption.formatted
)
```