### PR TITLE
Feature/make string option constants

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -36,6 +36,9 @@ Dimension = namedtuple("_Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
 ValueRenderOption = namedtuple(
     "_ValueRenderOption", ["formatted", "unformatted", "formula"]
 )("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
+ValueInputOption = namedtuple(
+    "_ValueInputOption", ["raw", "user_entered"]
+)("RAW", "USER_ENTERED")
 
 
 def convert_credentials(credentials):
@@ -354,7 +357,8 @@ def a1_range_to_grid_range(name, sheet_id=None):
 
     start_row_index, start_column_index = _a1_to_rowcol_unbounded(start_label)
 
-    end_row_index, end_column_index = _a1_to_rowcol_unbounded(end_label or start_label)
+    end_row_index, end_column_index = _a1_to_rowcol_unbounded(
+        end_label or start_label)
 
     if start_row_index > end_row_index:
         start_row_index, end_row_index = end_row_index, start_row_index
@@ -369,7 +373,12 @@ def a1_range_to_grid_range(name, sheet_id=None):
         "endColumnIndex": end_column_index,
     }
 
-    grid_range = {key: value for (key, value) in grid_range.items() if value != inf}
+    grid_range = {
+        key: value
+        for (key, value)
+        in grid_range.items()
+        if value != inf
+    }
 
     if sheet_id is not None:
         grid_range["sheetId"] = sheet_id

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -36,9 +36,9 @@ Dimension = namedtuple("_Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
 ValueRenderOption = namedtuple(
     "_ValueRenderOption", ["formatted", "unformatted", "formula"]
 )("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
-ValueInputOption = namedtuple(
-    "_ValueInputOption", ["raw", "user_entered"]
-)("RAW", "USER_ENTERED")
+ValueInputOption = namedtuple("_ValueInputOption", ["raw", "user_entered"])(
+    "RAW", "USER_ENTERED"
+)
 
 
 def convert_credentials(credentials):
@@ -357,8 +357,7 @@ def a1_range_to_grid_range(name, sheet_id=None):
 
     start_row_index, start_column_index = _a1_to_rowcol_unbounded(start_label)
 
-    end_row_index, end_column_index = _a1_to_rowcol_unbounded(
-        end_label or start_label)
+    end_row_index, end_column_index = _a1_to_rowcol_unbounded(end_label or start_label)
 
     if start_row_index > end_row_index:
         start_row_index, end_row_index = end_row_index, start_row_index
@@ -373,12 +372,7 @@ def a1_range_to_grid_range(name, sheet_id=None):
         "endColumnIndex": end_column_index,
     }
 
-    grid_range = {
-        key: value
-        for (key, value)
-        in grid_range.items()
-        if value != inf
-    }
+    grid_range = {key: value for (key, value) in grid_range.items() if value != inf}
 
     if sheet_id is not None:
         grid_range["sheetId"] = sheet_id

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -7,7 +7,7 @@ This module contains utility functions.
 """
 
 import re
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from functools import wraps
 from math import inf
 
@@ -31,6 +31,11 @@ A1_ADDR_ROW_COL_RE = re.compile(r"([A-Za-z]+)?([1-9]\d*)?$")
 
 URL_KEY_V1_RE = re.compile(r"key=([^&#]+)")
 URL_KEY_V2_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9-_]+)")
+
+Dimension = namedtuple("_Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
+ValueRenderOption = namedtuple(
+    "_ValueRenderOption", ["formatted", "unformatted", "formula"]
+)("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
 
 
 def convert_credentials(credentials):

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -10,6 +10,7 @@ from .cell import Cell
 from .urls import SPREADSHEET_URL, WORKSHEET_DRIVE_URL
 from .utils import (
     Dimension,
+    ValueInputOption,
     ValueRenderOption,
     a1_range_to_grid_range,
     a1_to_rowcol,
@@ -493,24 +494,24 @@ class Worksheet:
 
         data = self.spreadsheet.values_update(
             range_name,
-            params={"valueInputOption": "USER_ENTERED"},
+            params={"valueInputOption": ValueInputOption.user_entered},
             body={"values": [[value]]},
         )
 
         return data
 
-    def update_cells(self, cell_list, value_input_option="RAW"):
+    def update_cells(self, cell_list, value_input_option=ValueInputOption.raw):
         """Updates many cells at once.
 
         :param list cell_list: List of :class:`Cell` objects to update.
         :param str value_input_option: (optional) How the input data should be
             interpreted. Possible values are:
 
-            ``RAW``
+            ``ValueInputOption.raw``
                 The values the user has entered will not be parsed and will be
                 stored as-is.
 
-            ``USER_ENTERED``
+            ``ValueInputOption.user_entered``
                 The values will be parsed as if the user typed them into the
                 UI. Numbers will stay as numbers, but strings may be converted
                 to numbers, dates, etc. following the same rules that are
@@ -672,11 +673,11 @@ class Worksheet:
         :param str value_input_option: (optional) How the input data should be
             interpreted. Possible values are:
 
-            ``RAW``
+            ``ValueInputOption.raw``
                 The values the user has entered will not be parsed and will be
                 stored as-is.
 
-            ``USER_ENTERED``
+            ``ValueInputOption.user_entered``
                 The values will be parsed as if the user typed them into the
                 UI. Numbers will stay as numbers, but strings may be converted
                 to numbers, dates, etc. following the same rules that are
@@ -717,7 +718,9 @@ class Worksheet:
             values = [[values]]
 
         if not kwargs["value_input_option"]:
-            kwargs["value_input_option"] = "RAW" if kwargs["raw"] else "USER_ENTERED"
+            kwargs["value_input_option"] = (
+                ValueInputOption.raw if kwargs["raw"] else ValueInputOption.user_entered
+            )
 
         params = filter_dict_values(
             {
@@ -758,11 +761,11 @@ class Worksheet:
         :param str value_input_option: (optional) How the input data should be
             interpreted. Possible values are:
 
-            ``RAW``
+            ``ValueInputOption.raw``
                 The values the user has entered will not be parsed and will be
                 stored as-is.
 
-            ``USER_ENTERED``
+            ``ValueInputOption.user_entered``
                 The values will be parsed as if the user typed them into the
                 UI. Numbers will stay as numbers, but strings may be converted
                 to numbers, dates, etc. following the same rules that are
@@ -786,7 +789,9 @@ class Worksheet:
         .. versionadded:: 3.3
         """
         if not kwargs["value_input_option"]:
-            kwargs["value_input_option"] = "RAW" if kwargs["raw"] else "USER_ENTERED"
+            kwargs["value_input_option"] = (
+                ValueInputOption.raw if kwargs["raw"] else ValueInputOption.user_entered
+            )
 
         data = [
             dict(vr, range=absolute_range_name(self.title, vr["range"])) for vr in data
@@ -1060,7 +1065,7 @@ class Worksheet:
     def append_row(
         self,
         values,
-        value_input_option="RAW",
+        value_input_option=ValueInputOption.raw,
         insert_data_option=None,
         table_range=None,
         include_values_in_response=False,
@@ -1098,7 +1103,7 @@ class Worksheet:
     def append_rows(
         self,
         values,
-        value_input_option="RAW",
+        value_input_option=ValueInputOption.raw,
         insert_data_option=None,
         table_range=None,
         include_values_in_response=False,
@@ -1110,8 +1115,9 @@ class Worksheet:
         :param list values: List of rows each row is List of values for
             the new row.
         :param str value_input_option: (optional) Determines how input data
-            should be interpreted. Possible values are ``RAW`` or
-            ``USER_ENTERED``. See `ValueInputOption`_ in the Sheets API.
+            should be interpreted. Possible values are ``ValueInputOption.raw``
+            or ``ValueInputOption.user_entered``.
+            See `ValueInputOption`_ in the Sheets API.
         :param str insert_data_option: (optional) Determines how the input data
             should be inserted. See `InsertDataOption`_ in the Sheets API
             reference.
@@ -1137,7 +1143,7 @@ class Worksheet:
 
         return self.spreadsheet.values_append(range_label, params, body)
 
-    def insert_row(self, values, index=1, value_input_option="RAW"):
+    def insert_row(self, values, index=1, value_input_option=ValueInputOption.raw):
         """Adds a row to the worksheet at the specified index and populates it
         with values.
 
@@ -1146,14 +1152,15 @@ class Worksheet:
         :param list values: List of values for the new row.
         :param int index: (optional) Offset for the newly inserted row.
         :param str value_input_option: (optional) Determines how input data
-            should be interpreted. Possible values are ``RAW`` or
-            ``USER_ENTERED``. See `ValueInputOption`_ in the Sheets API.
+            should be interpreted. Possible values are ``ValueInputOption.raw``
+            or ``ValueInputOption.user_entered``.
+            See `ValueInputOption`_ in the Sheets API.
 
         .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
         """
         return self.insert_rows([values], index, value_input_option=value_input_option)
 
-    def insert_rows(self, values, row=1, value_input_option="RAW"):
+    def insert_rows(self, values, row=1, value_input_option=ValueInputOption.raw):
         """Adds multiple rows to the worksheet at the specified index and
         populates them with values.
 
@@ -1162,8 +1169,9 @@ class Worksheet:
             more values than columns.
         :param int row: Start row to update (one-based). Defaults to 1 (one).
         :param str value_input_option: (optional) Determines how input data
-            should be interpreted. Possible values are ``RAW`` or
-            ``USER_ENTERED``. See `ValueInputOption`_ in the Sheets API.
+            should be interpreted. Possible values are ``ValueInputOption.raw``
+            or ``ValueInputOption.user_entered``.
+            See `ValueInputOption`_ in the Sheets API.
         """
         body = {
             "requests": [
@@ -1190,7 +1198,7 @@ class Worksheet:
 
         return self.spreadsheet.values_append(range_label, params, body)
 
-    def insert_cols(self, values, col=1, value_input_option="RAW"):
+    def insert_cols(self, values, col=1, value_input_option=ValueInputOption.raw):
         """Adds multiple new cols to the worksheet at specified index and
         populates them with values.
 
@@ -1199,8 +1207,9 @@ class Worksheet:
             if there are more values than columns.
         :param int col: Start col to update (one-based). Defaults to 1 (one).
         :param str value_input_option: (optional) Determines how input data
-            should be interpreted. Possible values are ``RAW`` or
-            ``USER_ENTERED``. See `ValueInputOption`_ in the Sheets API.
+            should be interpreted. Possible values are ``ValueInputOption.raw``
+            or ``ValueInputOption.user_entered``.
+            See `ValueInputOption`_ in the Sheets API.
         """
         body = {
             "requests": [
@@ -1317,7 +1326,7 @@ class Worksheet:
     def delete_dimension(self, dimension, start_index, end_index=None):
         """Deletes multi rows from the worksheet at the specified index.
 
-        :param str dimension: A dimension to delete. ``ROWS`` or ``COLUMNS``.
+        :param str dimension: A dimension to delete. ``Dimension.rows`` or ``Dimension.cols``.
         :param int start_index: Index of a first row for deletion.
         :param int end_index: Index of a last row for deletion. When
             ``end_index`` is not specified this method only deletes a single

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -6,10 +6,11 @@ This module contains common worksheets' models.
 
 """
 
-from collections import namedtuple
 from .cell import Cell
 from .urls import SPREADSHEET_URL, WORKSHEET_DRIVE_URL
 from .utils import (
+    Dimension,
+    ValueRenderOption,
     a1_range_to_grid_range,
     a1_to_rowcol,
     absolute_range_name,
@@ -23,12 +24,6 @@ from .utils import (
     numericise_all,
     rowcol_to_a1,
 )
-
-Dimension = namedtuple('_Dimension', ['rows', 'cols'])('ROWS', 'COLUMNS')
-ValueRenderOption = namedtuple(
-    '_ValueRenderOption',
-    ['formatted', 'unformatted', 'formula']
-)('FORMATTED_VALUE', 'UNFORMATTED_VALUE', 'FORMULA')
 
 
 class ValueRange(list):
@@ -143,7 +138,7 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+        :type value_render_option:  ( `ValueRenderOption.formatted` |
                                     `ValueRenderOption.unformatted` |
                                     `ValueRenderOption.formula` )
 
@@ -169,7 +164,7 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+        :type value_render_option:  ( `ValueRenderOption.formatted` |
                                     `ValueRenderOption.unformatted` |
                                     `ValueRenderOption.formula` )
 
@@ -273,7 +268,7 @@ class Worksheet:
             non empty cells.
 
         :param str major_dimension: (optional) The major dimension of the
-            values. Either ``ROWS`` or ``COLUMNS``. Defaults to ``ROWS``
+            values. `Dimension.rows`("ROWS") or `Dimension.cols`("COLUMNS"). Defaults to Dimension.rows
 
         :param str value_render_option: (optional) Determines how values should
             be rendered in the the output. See `ValueRenderOption`_ in
@@ -462,7 +457,7 @@ class Worksheet:
             range_name,
             params={
                 "valueRenderOption": value_render_option,
-                "majorDimension":  Dimension.cols,
+                "majorDimension": Dimension.cols,
             },
         )
 

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -462,7 +462,7 @@ class Worksheet:
             range_name,
             params={
                 "valueRenderOption": value_render_option,
-                "majorDimension": "COLUMNS",
+                "majorDimension":  Dimension.cols,
             },
         )
 
@@ -1033,7 +1033,7 @@ class Worksheet:
                     "autoResizeDimensions": {
                         "dimensions": {
                             "sheetId": self.id,
-                            "dimension": "COLUMNS",
+                            "dimension": Dimension.cols,
                             "startIndex": int(start_column_index),
                             "endIndex": int(end_column_index),
                         }
@@ -1176,7 +1176,7 @@ class Worksheet:
                     "insertDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": "ROWS",
+                            "dimension": Dimension.rows,
                             "startIndex": row - 1,
                             "endIndex": len(values) + row - 1,
                         }
@@ -1191,7 +1191,7 @@ class Worksheet:
 
         params = {"valueInputOption": value_input_option}
 
-        body = {"majorDimension": "ROWS", "values": values}
+        body = {"majorDimension": Dimension.rows, "values": values}
 
         return self.spreadsheet.values_append(range_label, params, body)
 
@@ -1213,7 +1213,7 @@ class Worksheet:
                     "insertDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": "COLUMNS",
+                            "dimension": Dimension.cols,
                             "startIndex": col - 1,
                             "endIndex": len(values) + col - 1,
                         }
@@ -1228,7 +1228,7 @@ class Worksheet:
 
         params = {"valueInputOption": value_input_option}
 
-        body = {"majorDimension": "COLUMNS", "values": values}
+        body = {"majorDimension": Dimension.cols, "values": values}
 
         return self.spreadsheet.values_append(range_label, params, body)
 
@@ -1365,7 +1365,7 @@ class Worksheet:
             worksheet.delete_rows(2)
 
         """
-        return self.delete_dimension("ROWS", start_index, end_index)
+        return self.delete_dimension(Dimension.rows, start_index, end_index)
 
     def delete_columns(self, start_index, end_index=None):
         """Deletes multiple columns from the worksheet at the specified index.
@@ -1375,7 +1375,7 @@ class Worksheet:
             When end_index is not specified this method only deletes a single
             column at ``start_index``.
         """
-        return self.delete_dimension("COLUMNS", start_index, end_index)
+        return self.delete_dimension(Dimension.cols, start_index, end_index)
 
     def clear(self):
         """Clears all cells in the worksheet."""

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -6,6 +6,7 @@ This module contains common worksheets' models.
 
 """
 
+from collections import namedtuple
 from .cell import Cell
 from .urls import SPREADSHEET_URL, WORKSHEET_DRIVE_URL
 from .utils import (
@@ -22,6 +23,12 @@ from .utils import (
     numericise_all,
     rowcol_to_a1,
 )
+
+Dimension = namedtuple('_Dimension', ['rows', 'cols'])('ROWS', 'COLUMNS')
+ValueRenderOption = namedtuple(
+    '_ValueRenderOption',
+    ['formatted', 'unformatted', 'formula']
+)('FORMATTED_VALUE', 'UNFORMATTED_VALUE', 'FORMULA')
 
 
 class ValueRange(list):
@@ -127,7 +134,7 @@ class Worksheet:
         """Number of frozen columns."""
         return self._properties["gridProperties"].get("frozenColumnCount", 0)
 
-    def acell(self, label, value_render_option="FORMATTED_VALUE"):
+    def acell(self, label, value_render_option=ValueRenderOption.formatted):
         """Returns an instance of a :class:`gspread.models.Cell`.
 
         :param label: Cell label in A1 notation
@@ -136,7 +143,9 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option: str
+        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+                                    `ValueRenderOption.unformatted` |
+                                    `ValueRenderOption.formula` )
 
         .. _ValueRenderOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption
 
@@ -149,7 +158,7 @@ class Worksheet:
             *(a1_to_rowcol(label)), value_render_option=value_render_option
         )
 
-    def cell(self, row, col, value_render_option="FORMATTED_VALUE"):
+    def cell(self, row, col, value_render_option=ValueRenderOption.formatted):
         """Returns an instance of a :class:`gspread.models.Cell` located at
         `row` and `col` column.
 
@@ -160,7 +169,9 @@ class Worksheet:
         :param value_render_option: (optional) Determines how values should be
                                     rendered in the the output. See
                                     `ValueRenderOption`_ in the Sheets API.
-        :type value_render_option: str
+        :type value_render_option:  ( `ValueRenderOption.formatted` | 
+                                    `ValueRenderOption.unformatted` |
+                                    `ValueRenderOption.formula` )
 
         .. _ValueRenderOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption
 
@@ -270,17 +281,17 @@ class Worksheet:
 
             Possible values are:
 
-            ``FORMATTED_VALUE``
+            ``ValueRenderOption.formatted``
                 (default) Values will be calculated and formatted according
                 to the cell's formatting. Formatting is based on the
                 spreadsheet's locale, not the requesting user's locale.
 
-            ``UNFORMATTED_VALUE``
+            ``ValueRenderOption.unformatted``
                 Values will be calculated, but not formatted in the reply.
                 For example, if A1 is 1.23 and A2 is =A1 and formatted as
                 currency, then A2 would return the number 1.23.
 
-            ``FORMULA``
+            ``ValueRenderOption.formula``
                 Values will not be calculated. The reply will include
                 the formulas. For example, if A1 is 1.23 and A2 is =A1 and
                 formatted as currency, then A2 would return "=A1".
@@ -289,8 +300,8 @@ class Worksheet:
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            ``value_render_option`` is ``FORMATTED_VALUE``. The default
-            ``date_time_render_option`` is ``SERIAL_NUMBER``.
+            ``value_render_option`` is ``ValueRenderOption.formatted``.
+            The default ``date_time_render_option`` is ``SERIAL_NUMBER``.
 
         .. note::
 
@@ -311,10 +322,10 @@ class Worksheet:
             worksheet.get_values('my_range')
 
             # Return unformatted values (e.g. numbers as numbers)
-            worksheet.get_values('A2:B4', value_render_option='UNFORMATTED_VALUE')
+            worksheet.get_values('A2:B4', value_render_option=ValueRenderOption.unformatted)
 
             # Return cell values without calculating formulas
-            worksheet.get_values('A2:B4', value_render_option='FORMULA')
+            worksheet.get_values('A2:B4', value_render_option=ValueRenderOption.formula)
         """
         try:
             return fill_gaps(self.get(range_name, **kwargs))
@@ -429,7 +440,7 @@ class Worksheet:
         except KeyError:
             return []
 
-    def col_values(self, col, value_render_option="FORMATTED_VALUE"):
+    def col_values(self, col, value_render_option=ValueRenderOption.formatted):
         """Returns a list of all values in column `col`.
 
         Empty cells in this list will be rendered as :const:`None`.
@@ -559,11 +570,11 @@ class Worksheet:
 
         :param str value_render_option: (optional) How values should be
             represented in the output. The default render option is
-            ``FORMATTED_VALUE``.
+            ``ValueRenderOption.formatted``.
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            ``value_render_option`` is ``FORMATTED_VALUE``. The default
+            ``value_render_option`` is ``ValueRenderOption.formatted``. The default
             ``date_time_render_option`` is ``SERIAL_NUMBER``.
 
         Examples::
@@ -612,11 +623,11 @@ class Worksheet:
 
         :param str value_render_option: (optional) How values should be
             represented in the output. The default render option
-            is ``FORMATTED_VALUE``.
+            is ``ValueRenderOption.formatted``.
 
         :param str date_time_render_option: (optional) How dates, times, and
             durations should be represented in the output. This is ignored if
-            value_render_option is ``FORMATTED_VALUE``. The default dateTime
+            value_render_option is ``ValueRenderOption.formatted``. The default dateTime
             render option is ``SERIAL_NUMBER``.
 
         .. versionadded:: 3.3

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -560,7 +560,9 @@ class WorksheetTest(GspreadTest):
         cell_list = self.sheet.range("A1:D2")
         for cell, value in zip(cell_list, itertools.chain(*rows)):
             cell.value = value
-        self.sheet.update_cells(cell_list, value_input_option="USER_ENTERED")
+        self.sheet.update_cells(
+            cell_list, value_input_option=utils.ValueInputOption.user_entered
+        )
 
         # default, formatted read
         read_records = self.sheet.get_all_records()
@@ -571,7 +573,7 @@ class WorksheetTest(GspreadTest):
 
         # unformatted read
         read_records = self.sheet.get_all_records(
-            value_render_option="UNFORMATTED_VALUE"
+            value_render_option=utils.ValueRenderOption.unformatted
         )
         expected_keys = [2, 43831, "string", 53]
         expected_values = [3 / 2, 0.12, 36162, ""]
@@ -579,7 +581,9 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(read_records[0], d0)
 
         # formula read
-        read_records = self.sheet.get_all_records(value_render_option="FORMULA")
+        read_records = self.sheet.get_all_records(
+            value_render_option=utils.ValueRenderOption.formula
+        )
         expected_keys = ["=4/2", 43831, "string", 53]
         expected_values = ["=3/2", 0.12, 36162, ""]
         d0 = dict(zip(expected_keys, expected_values))
@@ -596,12 +600,14 @@ class WorksheetTest(GspreadTest):
         cell_list = self.sheet.range("A1:D2")
         for cell, value in zip(cell_list, itertools.chain(*rows)):
             cell.value = value
-        self.sheet.update_cells(cell_list, value_input_option="USER_ENTERED")
+        self.sheet.update_cells(
+            cell_list, value_input_option=utils.ValueInputOption.user_entered
+        )
 
         read_records = self.sheet.get_all_records(
             default_blank="empty",
             allow_underscores_in_numeric_literals=True,
-            value_render_option="UNFORMATTED_VALUE",
+            value_render_option=utils.ValueRenderOption.unformatted,
         )
         expected_values = [3 / 2, 0.12, "empty", 321]
         d0 = dict(zip(rows[0], expected_values))
@@ -664,7 +670,7 @@ class WorksheetTest(GspreadTest):
         self.sheet.update_acell("B2", formula)
         values = [next(sg) for i in range(num_cols + 4)]
         self.sheet.insert_row(values, 1)
-        b3 = self.sheet.acell("B3", value_render_option="FORMULA")
+        b3 = self.sheet.acell("B3", value_render_option=utils.ValueRenderOption.formula)
         self.assertEqual(b3.value, formula)
 
     @pytest.mark.vcr()


### PR DESCRIPTION
Replace the use of string values for the following option by an enum:
- Dimension: ROWS, COLUMNS
- ValueRenderOption: FORMATTED_VALUE, UNFORMATTED_VALUE, FORMULA
- ValueInputOption: RAW, USER_ENTERED

This PR is a take over from #949 

Thanks again @ccppoo for your contribution.