### PR TITLE
Codespell skip docs build folder

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,7 +46,7 @@ ter Christian Clauss <cclauss@me.com> 1630103641 +0200 (#869 by @cclaus)
 
 * allow tests to run on windows, add and improve tests in WorksheetTests, add test on unbounded range,
   use canonical range as specified in the API, add test cassettes, prevent InvalidGridRange,
-  improve code formating (#937 by @Fendse)
+  improve code formatting (#937 by @Fendse)
 
 * fix fully qualified class names in API documentation (#944 by @geoffbeier)
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands = pytest {posargs} tests/
 description = Run code linters
 deps = -r lint-requirements.txt
 commands = black --check .
-        codespell --skip=".tox,.git" .
+        codespell --skip=".tox,.git,./docs/build" .
         flake8 --ignore=E203 --max-complexity=10 --max-line-length=255 \
             --show-source --statistics .
         isort --check-only --profile black .


### PR DESCRIPTION
when running codespell skip documentation resuling build folder.

closes #960