### PR TITLE
Improvement/add oauth from dict

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -178,8 +178,44 @@ You only need to do authorization in the browser once, following runs will reuse
 
     Make sure you store the credentials file in a safe place.
 
-.. attention:: Security
-    Credentials file and authorized credentials contain sensitive data. **Do not share these files with others** and treat them like private keys.
+There is also the option to pass your credentials directly as a python dict. This way you don't have to store them as files or you can store them in your favorite password
+manager.
+
+::
+
+    import gspread
+
+    my_creds = {
+        ...
+    }
+    gc, authorized_user = gspread.oauth(my_creds)
+
+    sh = gc.open("Example spreadsheet")
+
+    print(sh.sheet1.get('A1'))
+
+Once authenticated you must store the returned json string containing your authenticated user information. Provide that details as a python dict
+as second argument in your next `oauth` request to be directly authenticated and skip the flow.
+
+.. NOTE::
+    The second time if your authorized user has not expired, you can omit the credentials.
+    Be aware, if the authorized user has expired your credentials are required to authenticate again.
+
+::
+
+    import gspread
+
+    my_creds = {
+        ...
+    }
+    gc, authorized_user = gspread.oauth(my_creds, authorized_user)
+
+    sh = gc.open("Example spreadsheet")
+
+    print(sh.sheet1.get('A1'))
+
+.. warning::
+    Security credentials file and authorized credentials contain sensitive data. **Do not share these files with others** and treat them like private keys.
 
     If you are concerned about giving the application access to your spreadsheets and Drive, use Service Accounts.
 

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -13,7 +13,7 @@ __version__ = "5.0.0"
 __author__ = "Anton Burnashev"
 
 
-from .auth import oauth, service_account, service_account_from_dict
+from .auth import oauth, oauth_from_dict, service_account, service_account_from_dict
 from .cell import Cell
 from .client import Client
 from .exceptions import (


### PR DESCRIPTION
Add oauth from dict

As requested from users, add a function to authenticate
using oauth without any JSON file.
Take the necessary credentials as python dict.

Must return the authorized user to the caller and the client to connect to Gspread.

closes #786