### PR TITLE
Fix documentation about oauth

### DIFF
--- a/docs/oauth2.rst
+++ b/docs/oauth2.rst
@@ -185,10 +185,18 @@ manager.
 
     import gspread
 
-    my_creds = {
-        ...
+    credentials = {
+        {
+            "installed": {
+                "client_id": "12345678901234567890abcdefghijklmn.apps.googleusercontent.com",
+                "project_id": "my-project1234",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                ...
+            }
+        }
     }
-    gc, authorized_user = gspread.oauth(my_creds)
+    gc, authorized_user = gspread.oauth_from_dict(credentials)
 
     sh = gc.open("Example spreadsheet")
 
@@ -205,10 +213,27 @@ as second argument in your next `oauth` request to be directly authenticated and
 
     import gspread
 
-    my_creds = {
-        ...
+    credentials = {
+        "installed": {
+            "client_id": "12345678901234567890abcdefghijklmn.apps.googleusercontent.com",
+            "project_id": "my-project1234",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            ...
+        }
     }
-    gc, authorized_user = gspread.oauth(my_creds, authorized_user)
+    authorized_user = {
+        "refresh_token": "8//ThisALONGTOkEn....",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "client_id": "12345678901234567890abcdefghijklmn.apps.googleusercontent.com",
+        "client_secret": "MySecRet....",
+        "scopes": [
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/drive"
+        ],
+        "expiry": "1070-01-01T00:00:00.000001Z"
+    }
+    gc, authorized_user = gspread.oauth_from_dict(credentials, authorized_user)
 
     sh = gc.open("Example spreadsheet")
 


### PR DESCRIPTION
Fix documentation for method `oauth_from_dict` and provide
a larger example of the dict to pass to the method.

fixes #974