### PR TITLE
Copy comments when during spreadsheet copy

### DIFF
--- a/gspread/urls.py
+++ b/gspread/urls.py
@@ -25,5 +25,9 @@ DRIVE_FILES_API_V2_URL = "https://www.googleapis.com/drive/v2/files"
 DRIVE_FILES_API_V3_URL = "https://www.googleapis.com/drive/v3/files"
 DRIVE_FILES_UPLOAD_API_V2_URL = "https://www.googleapis.com" "/upload/drive/v2/files"
 
+DRIVE_FILES_API_V3_COMMENTS_URL = (
+    "https://www.googleapis.com/drive/v3/files/%s/comments"
+)
+
 SPREADSHEET_DRIVE_URL = "https://docs.google.com/spreadsheets/d/%s"
 WORKSHEET_DRIVE_URL = SPREADSHEET_URL + "#gid=%s"

--- a/tests/cassettes/ClientTest.test_copy.json
+++ b/tests/cassettes/ClientTest.test_copy.json
@@ -64,9 +64,6 @@
                         "Origin",
                         "X-Origin"
                     ],
-                    "Transfer-Encoding": [
-                        "chunked"
-                    ],
                     "X-Content-Type-Options": [
                         "nosniff"
                     ],
@@ -133,9 +130,6 @@
                         "Origin",
                         "X-Origin",
                         "Referer"
-                    ],
-                    "Transfer-Encoding": [
-                        "chunked"
                     ],
                     "X-Content-Type-Options": [
                         "nosniff"
@@ -221,9 +215,6 @@
                     "Pragma": [
                         "no-cache"
                     ],
-                    "Transfer-Encoding": [
-                        "chunked"
-                    ],
                     "X-Content-Type-Options": [
                         "nosniff"
                     ],
@@ -290,9 +281,6 @@
                         "Origin",
                         "X-Origin",
                         "Referer"
-                    ],
-                    "Transfer-Encoding": [
-                        "chunked"
                     ],
                     "X-Content-Type-Options": [
                         "nosniff"
@@ -361,9 +349,6 @@
                         "X-Origin",
                         "Referer"
                     ],
-                    "Transfer-Encoding": [
-                        "chunked"
-                    ],
                     "X-Content-Type-Options": [
                         "nosniff"
                     ],
@@ -431,9 +416,6 @@
                         "X-Origin",
                         "Referer"
                     ],
-                    "Transfer-Encoding": [
-                        "chunked"
-                    ],
                     "X-Content-Type-Options": [
                         "nosniff"
                     ],
@@ -449,6 +431,84 @@
                 },
                 "body": {
                     "string": "{\n  \"spreadsheetId\": \"150digw5026ePu8AXg5YnY9WTxG3VFOg02KFldhy1-Js\",\n  \"properties\": {\n    \"title\": \"Copy of Original\",\n    \"locale\": \"en_US\",\n    \"autoRecalc\": \"ON_CHANGE\",\n    \"timeZone\": \"Etc/GMT\",\n    \"defaultFormat\": {\n      \"backgroundColor\": {\n        \"red\": 1,\n        \"green\": 1,\n        \"blue\": 1\n      },\n      \"padding\": {\n        \"top\": 2,\n        \"right\": 3,\n        \"bottom\": 2,\n        \"left\": 3\n      },\n      \"verticalAlignment\": \"BOTTOM\",\n      \"wrapStrategy\": \"OVERFLOW_CELL\",\n      \"textFormat\": {\n        \"foregroundColor\": {},\n        \"fontFamily\": \"arial,sans,sans-serif\",\n        \"fontSize\": 10,\n        \"bold\": false,\n        \"italic\": false,\n        \"strikethrough\": false,\n        \"underline\": false,\n        \"foregroundColorStyle\": {\n          \"rgbColor\": {}\n        }\n      },\n      \"backgroundColorStyle\": {\n        \"rgbColor\": {\n          \"red\": 1,\n          \"green\": 1,\n          \"blue\": 1\n        }\n      }\n    },\n    \"spreadsheetTheme\": {\n      \"primaryFontFamily\": \"Arial\",\n      \"themeColors\": [\n        {\n          \"colorType\": \"BACKGROUND\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 1,\n              \"blue\": 1\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT3\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.9843137,\n              \"green\": 0.7372549,\n              \"blue\": 0.015686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT1\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.25882354,\n              \"green\": 0.52156866,\n              \"blue\": 0.95686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT5\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 0.42745098,\n              \"blue\": 0.003921569\n            }\n          }\n        },\n        {\n          \"colorType\": \"TEXT\",\n          \"color\": {\n            \"rgbColor\": {}\n          }\n        },\n        {\n          \"colorType\": \"ACCENT2\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.91764706,\n              \"green\": 0.2627451,\n              \"blue\": 0.20784314\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT4\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.20392157,\n              \"green\": 0.65882355,\n              \"blue\": 0.3254902\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT6\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.27450982,\n              \"green\": 0.7411765,\n              \"blue\": 0.7764706\n            }\n          }\n        },\n        {\n          \"colorType\": \"LINK\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.06666667,\n              \"green\": 0.33333334,\n              \"blue\": 0.8\n            }\n          }\n        }\n      ]\n    }\n  },\n  \"sheets\": [\n    {\n      \"properties\": {\n        \"sheetId\": 0,\n        \"title\": \"Sheet1\",\n        \"index\": 0,\n        \"sheetType\": \"GRID\",\n        \"gridProperties\": {\n          \"rowCount\": 1000,\n          \"columnCount\": 26\n        }\n      }\n    }\n  ],\n  \"spreadsheetUrl\": \"https://docs.google.com/spreadsheets/d/150digw5026ePu8AXg5YnY9WTxG3VFOg02KFldhy1-Js/edit\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://www.googleapis.com/drive/v3/files/1SEdIqro5tINS769UEKfObAwh2ufUh5SqPhWUeoQGXhQ/comments?fields=comments%2Fcontent%2Ccomments%2Fanchor%2CnextPageToken&includeDeleted=False&pageSize=100&pageToken=",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.27.1"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-XSS-Protection": [
+                        "1; mode=block"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Content-Security-Policy": [
+                        "frame-ancestors 'self'"
+                    ],
+                    "Server": [
+                        "GSE"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Expires": [
+                        "Mon, 01 Jan 1990 00:00:00 GMT"
+                    ],
+                    "Date": [
+                        "Fri, 07 Jan 2022 14:33:09 GMT"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+                    ],
+                    "content-length": [
+                        "20"
+                    ]
+                },
+                "body": {
+                    "string": "{\n \"comments\": []\n}\n"
                 }
             }
         }


### PR DESCRIPTION
When copying a spreadsheet, if `copy_comments` is True
copy all the comments from original spreadsheet.

When requesting all the comments, the API limit the maximum size of
a page to 100 comments.
Request only the necessary fields from the list of current comments,
to create the new comments iterate over all the comments and push them directly,
no need to change anything.

Recorded the new requests for the tests suite.

closes #978