### PR TITLE
Feature/prevent insert row to sheet with colon

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -56,7 +56,7 @@ def local_server_flow(client_config, scopes, port=0):
 
     Creates an OAuth flow and runs `google_auth_oauthlib.flow.InstalledAppFlow.run_local_server <https://google-auth-oauthlib.readthedocs.io/en/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.InstalledAppFlow.run_local_server>`_.
     This will start a local web server and open the authorization URL in
-    the user’s browser.
+    the user's browser.
 
     Pass this function to ``flow`` parameter of :meth:`~gspread.oauth` to run
     a local server flow.
@@ -99,7 +99,7 @@ def oauth(
     r"""Authenticate with OAuth Client ID.
 
     By default this function will use the local server strategy and open
-    the authorization URL in the user’s browser::
+    the authorization URL in the user's browser::
 
         gc = gspread.oauth()
 

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1188,6 +1188,14 @@ class Worksheet:
             or ``ValueInputOption.user_entered``.
             See `ValueInputOption`_ in the Sheets API.
         """
+
+        # can't insert row on sheet with colon ':'
+        # in its name, see issue: https://issuetracker.google.com/issues/36761154
+        if ":" in self.title:
+            raise GSpreadException(
+                "can't insert row in worksheet with colon ':' in its name. See issue: https://issuetracker.google.com/issues/36761154"
+            )
+
         body = {
             "requests": [
                 {


### PR DESCRIPTION
Google API does not work when trying to insert a new row
in a worksheet that contain a colon ':' in its name.

Prevent users from insert row in such case so they have a clear error
message instead of the error message returned from the API.

See issue: https://issuetracker.google.com/issues/36761154

closes https://github.com/burnash/gspread/issues/822