### PR TITLE
add method list protected ranges

### DIFF
--- a/gspread/spreadsheet.py
+++ b/gspread/spreadsheet.py
@@ -615,3 +615,18 @@ class Spreadsheet:
         }
 
         return self.batch_update(body)
+
+    def list_protected_ranges(self, sheetid):
+        """Lists the spreadsheet's protected named ranges"""
+        sheets = self.fetch_sheet_metadata(
+            params={"fields": "sheets.properties,sheets.protectedRanges"}
+        )["sheets"]
+
+        try:
+            sheet = finditem(
+                lambda sheet: sheet["properties"]["sheetId"] == sheetid, sheets
+            )
+
+            return sheet["protectedRanges"]
+        except (StopIteration, KeyError):
+            return []


### PR DESCRIPTION
Add a new method to list all protected ranges.
This method can't be tested in our test suite because it requires to
create a new spreadsheet with a protected range. This requires us to add
the email address used to record the test interactions to create a valid
protected range. This leads to my personal service account leaked in GH.

It has been tested manually and works fine.

Closes #999