### PR TITLE
added 'AppAssertionCredentials' to list of valid oauth2 names

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -50,6 +50,7 @@ def convert_credentials(credentials):
         "OAuth2Credentials",
         "AccessTokenCredentials",
         "GoogleCredentials",
+        "AppAssertionCredentials",
     ):
         return _convert_oauth(credentials)
     elif isinstance(credentials, Credentials):


### PR DESCRIPTION
It appears that Google Colab has changed how it supplies default credentials using the GoogleCredentials.get_application_default(). Now when you authorize through colab--google.colab.auth--the class name (GoogleCredentials.get_application_default().__class__.__name__) is titled AppAssertionCredentials. This is not a valid type according to gspread. I added this in the valid names for the class so that it would work for Google Colab's base form of authentication. If you try to use colab's current form of auth with the current state of gspread, the following TypeError is raised.

    raise TypeError(
        "Credentials need to be from either oauth2client or from google-auth."
    ) 