### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Releases
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Run linter
+      run: tox -e lint
+    - name: Run tests
+      run: tox -e py
+    - name: Build package
+      run: tox -e build
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: dist/gspread-*
+        token: ${{ secrets.GH_TOKEN }}
+        generateReleaseNotes: True
+        artifactErrorsFailBuild: True
+    - name: Publish to TestPyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Try to reduce the necessary steps to make a new release. Use this new
github action to:

1. run linter and tests
2. generate package
3. create new github release and upload packages
4. publish new packages to PyPi

The pre-required human steps are:

1. change the version number
2. fill the file HISTORY.RST
3. push new commit
4. create tag
5. push tag -> this will trigger the release process

I double checked every steps, everything looks correct, but we'll only know for sure during the next release :wink: 

closes #971 