### PR TITLE
Fix error message in `get_all_records`

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -440,7 +440,7 @@ class Worksheet:
         if not expected & headers == expected:
             raise GSpreadException(
                 "the given 'expected_headers' contains unknown headers: {}".format(
-                    expected & headers
+                    expected - headers
                 )
             )
 


### PR DESCRIPTION
In method `get_all_record` if a given set of headers is passed
and contains extra values that are not part of the current worksheet
we display an error message that contains these extra values.

previously: a & b => will display all common values from the 2 sets
now: a - b => will display values in set a and not in set b

closes #1027