### PR TITLE
Encode string to utf-8 when importing CSV content

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -387,6 +387,10 @@ class Client:
            replaces the contents of the first worksheet.
 
         """
+        # Make sure we send utf-8
+        if type(data) is str:
+            data = data.encode("utf-8")
+
         headers = {"Content-Type": "text/csv"}
         url = "{}/{}".format(DRIVE_FILES_UPLOAD_API_V2_URL, file_id)
 


### PR DESCRIPTION
When importing CSV content to a spreadsheet force encode it to UTF-8
format. The http module does not handle other formats for string (like
latin-1).

closes #867