### PR TITLE
Remove deprecated method delete_row

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1438,23 +1438,6 @@ class Worksheet:
 
         return self.spreadsheet.values_append(range_label, params, body)
 
-    def delete_row(self, index):
-        """.. deprecated:: 5.0
-
-        Deletes the row from the worksheet at the specified index.
-
-        :param int index: Index of a row for deletion.
-        """
-        import warnings
-
-        warnings.warn(
-            "Worksheet.delete_row() is deprecated, "
-            "Please use `Worksheet.delete_rows()` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.delete_rows(index)
-
     @cast_to_a1_notation
     def add_protected_range(
         self,

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -753,20 +753,6 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(b3.value, formula)
 
     @pytest.mark.vcr()
-    def test_delete_row(self):
-        sg = self._sequence_generator()
-
-        for i in range(5):
-            value_list = [next(sg) for i in range(10)]
-            self.sheet.append_row(value_list)
-
-        prev_row = self.sheet.row_values(1)
-        next_row = self.sheet.row_values(3)
-        self.sheet.delete_row(2)
-        self.assertEqual(self.sheet.row_values(1), prev_row)
-        self.assertEqual(self.sheet.row_values(2), next_row)
-
-    @pytest.mark.vcr()
     def test_clear(self):
         rows = [
             ["", "", "", ""],


### PR DESCRIPTION
Fixes #1041

I removed the method, the according test and also run the tests, the format command and the lint command so everything seems to be in order.
I am not sure if I should update the documentation somehow though.