### PR TITLE
Add `client_factory` parameter to `auth` methods

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,8 @@
 Release History
 ===============
 
+* Add `client_factory` param to `auth` methods by @jlumbroso in https://github.com/burnash/gspread/pull/1071
+
 5.4.0 (2022-06-01)
 ------------------
 * fix typo by @joswlv in https://github.com/burnash/gspread/pull/1031

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 Release History
 ===============
 
-* Add `client_factory` param to `auth` methods by @jlumbroso in https://github.com/burnash/gspread/pull/1071
+* Add `client_factory` param to `auth` methods by @jlumbroso in https://github.com/burnash/gspread/pull/1075
 
 5.4.0 (2022-06-01)
 ------------------

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -35,7 +35,7 @@ def authorize(credentials, client_factory=Client):
     By default :class:`gspread.Client` is used (but could also use
     :class:`gspread.BackoffClient` to avoid rate limiting).
 
-    :returns: `client_class` instance.
+    :returns: `client_factory` instance.
     """
 
     client = client_factory(auth=credentials)

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -13,7 +13,13 @@ __version__ = "5.4.0"
 __author__ = "Anton Burnashev"
 
 
-from .auth import authorize, oauth, oauth_from_dict, service_account, service_account_from_dict
+from .auth import (
+    authorize,
+    oauth,
+    oauth_from_dict,
+    service_account,
+    service_account_from_dict,
+)
 from .cell import Cell
 from .client import BackoffClient, Client, ClientFactory
 from .exceptions import (

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -15,7 +15,7 @@ __author__ = "Anton Burnashev"
 
 from .auth import oauth, oauth_from_dict, service_account, service_account_from_dict
 from .cell import Cell
-from .client import Client, ClientFactory
+from .client import BackoffClient, Client, ClientFactory
 from .exceptions import (
     CellNotFound,
     GSpreadException,
@@ -28,14 +28,15 @@ from .spreadsheet import Spreadsheet
 from .worksheet import Worksheet
 
 
-def authorize(credentials, client_class=Client):
+def authorize(credentials, client_factory=Client):
     """Login to Google API using OAuth2 credentials.
     This is a shortcut function which
-    instantiates `client_class`.
-    By default :class:`gspread.Client` is used.
+    instantiates using `client_factory`.
+    By default :class:`gspread.Client` is used (but could also use
+    :class:`gspread.BackoffClient` to avoid rate limiting).
 
     :returns: `client_class` instance.
     """
 
-    client = client_class(auth=credentials)
+    client = client_factory(auth=credentials)
     return client

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -13,7 +13,7 @@ __version__ = "5.4.0"
 __author__ = "Anton Burnashev"
 
 
-from .auth import oauth, oauth_from_dict, service_account, service_account_from_dict
+from .auth import authorize, oauth, oauth_from_dict, service_account, service_account_from_dict
 from .cell import Cell
 from .client import BackoffClient, Client, ClientFactory
 from .exceptions import (
@@ -26,17 +26,3 @@ from .exceptions import (
 )
 from .spreadsheet import Spreadsheet
 from .worksheet import Worksheet
-
-
-def authorize(credentials, client_factory=Client):
-    """Login to Google API using OAuth2 credentials.
-    This is a shortcut function which
-    instantiates using `client_factory`.
-    By default :class:`gspread.Client` is used (but could also use
-    :class:`gspread.BackoffClient` to avoid rate limiting).
-
-    :returns: `client_factory` instance.
-    """
-
-    client = client_factory(auth=credentials)
-    return client

--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -15,7 +15,7 @@ __author__ = "Anton Burnashev"
 
 from .auth import oauth, oauth_from_dict, service_account, service_account_from_dict
 from .cell import Cell
-from .client import Client
+from .client import Client, ClientFactory
 from .exceptions import (
     CellNotFound,
     GSpreadException,

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -49,6 +49,20 @@ DEFAULT_AUTHORIZED_USER_FILENAME = DEFAULT_CONFIG_DIR / "authorized_user.json"
 DEFAULT_SERVICE_ACCOUNT_FILENAME = DEFAULT_CONFIG_DIR / "service_account.json"
 
 
+def authorize(credentials, client_factory=Client):
+    """Login to Google API using OAuth2 credentials.
+    This is a shortcut/helper function which
+    instantiates a client using `client_factory`.
+    By default :class:`gspread.Client` is used (but could also use
+    :class:`gspread.BackoffClient` to avoid rate limiting).
+
+    :returns: An instance of the class produced by `client_factory`.
+    :rtype: :class:`gspread.client.Client`
+    """
+
+    return client_factory(auth=credentials)
+
+
 def local_server_flow(client_config, scopes, port=0):
     """Run an OAuth flow using a local server strategy.
 
@@ -168,7 +182,7 @@ def oauth(
         Defaults to :class:`gspread.Client` (but could also use
         :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: :class:`gspread.ClientFactory`
+    :rtype: :class:`gspread.client.Client`
     """
     authorized_user_filename = Path(authorized_user_filename)
     creds = load_credentials(filename=authorized_user_filename)
@@ -248,7 +262,7 @@ def oauth_from_dict(
         Defaults to :class:`gspread.Client` (but could also use
         :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: :class:`gspread.ClientFactory`
+    :rtype: (`gspread.client.Client`, str)
     """
 
     creds = None
@@ -293,7 +307,7 @@ def service_account(
         Defaults to :class:`gspread.Client` (but could also use
         :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: :class:`gspread.ClientFactory`
+    :rtype: :class:`gspread.client.Client`
     """
     creds = ServiceAccountCredentials.from_service_account_file(filename, scopes=scopes)
     return client_factory(auth=creds)
@@ -322,7 +336,7 @@ def service_account_from_dict(info, scopes=DEFAULT_SCOPES, client_factory=Client
         Defaults to :class:`gspread.Client` (but could also use
         :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: :class:`gspread.ClientFactory`
+    :rtype: :class:`gspread.client.Client`
     """
     creds = ServiceAccountCredentials.from_service_account_info(
         info=info,

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -8,7 +8,6 @@ Simple authentication with OAuth.
 
 import json
 import os
-import typing
 import warnings
 from pathlib import Path
 

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -163,12 +163,12 @@ def oauth(
 
             * `%APPDATA%\gspread\authorized_user.json` on Windows
             * `~/.config/gspread/authorized_user.json` everywhere else
-    :param :type:`gspread.ClientFactory` client_factory: A factory function
-        that returns a client class. Defaults to :class:`gspread.Client`
-        (but could also use :class:`gspread.BackoffClient` to avoid rate
-        limiting)
+    :type client_factory: :class:`gspread.ClientFactory`
+    :param client_factory: A factory function that returns a client class.
+        Defaults to :class:`gspread.Client` (but could also use
+        :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: :type:`gspread.ClientFactory`
+    :rtype: :class:`gspread.ClientFactory`
     """
     authorized_user_filename = Path(authorized_user_filename)
     creds = load_credentials(filename=authorized_user_filename)
@@ -243,12 +243,12 @@ def oauth_from_dict(
     :param list scopes: The scopes used to obtain authorization.
     :param function flow: OAuth flow to use for authentication.
         Defaults to :meth:`~gspread.auth.local_server_flow`
-    :param :type:`gspread.ClientFactory` client_factory: A factory function
-        that returns a client class. Defaults to :class:`gspread.Client`
-        (but could also use :class:`gspread.BackoffClient` to avoid rate
-        limiting)
+    :type client_factory: :class:`gspread.ClientFactory`
+    :param client_factory: A factory function that returns a client class.
+        Defaults to :class:`gspread.Client` (but could also use
+        :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: tuple(:type:`gspread.ClientFactory` , str)
+    :rtype: :class:`gspread.ClientFactory`
     """
 
     creds = None
@@ -288,12 +288,12 @@ def service_account(
 
     :param str filename: The path to the service account json file.
     :param list scopes: The scopes used to obtain authorization.
-    :param :type:`gspread.ClientFactory` client_factory: A factory function
-        that returns a client class. Defaults to :class:`gspread.Client`
-        (but could also use :class:`gspread.BackoffClient` to avoid rate
-        limiting)
+    :type client_factory: :class:`gspread.ClientFactory`
+    :param client_factory: A factory function that returns a client class.
+        Defaults to :class:`gspread.Client` (but could also use
+        :class:`gspread.BackoffClient` to avoid rate limiting)
 
-    :rtype: :type:`gspread.ClientFactory`
+    :rtype: :class:`gspread.ClientFactory`
     """
     creds = ServiceAccountCredentials.from_service_account_file(filename, scopes=scopes)
     return client_factory(auth=creds)
@@ -317,10 +317,10 @@ def service_account_from_dict(info, scopes=DEFAULT_SCOPES, client_factory=Client
 
     :param info (Mapping[str, str]): The service account info in Google format
     :param list scopes: The scopes used to obtain authorization.
-    :param :type:`gspread.ClientFactory` client_factory: A factory function
-        that returns a client class. Defaults to :class:`gspread.Client`
-        (but could also use :class:`gspread.BackoffClient` to avoid rate
-        limiting)
+    :type client_factory: :class:`gspread.ClientFactory`
+    :param client_factory: A factory function that returns a client class.
+        Defaults to :class:`gspread.Client` (but could also use
+        :class:`gspread.BackoffClient` to avoid rate limiting)
 
     :rtype: :class:`gspread.ClientFactory`
     """

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -8,6 +8,7 @@ Google API.
 """
 
 from http import HTTPStatus
+from typing import Type
 
 from google.auth.transport.requests import AuthorizedSession
 
@@ -54,7 +55,8 @@ class Client:
 
         self.auth.refresh(Request(self.session))
 
-        self.session.headers.update({"Authorization": "Bearer %s" % self.auth.token})
+        self.session.headers.update(
+            {"Authorization": "Bearer %s" % self.auth.token})
 
     def set_timeout(self, timeout):
         """How long to wait for the server to send
@@ -224,7 +226,8 @@ class Client:
         if folder_id is not None:
             payload["parents"] = [folder_id]
 
-        r = self.request("post", DRIVE_FILES_API_V3_URL, json=payload, params=params)
+        r = self.request("post", DRIVE_FILES_API_V3_URL,
+                         json=payload, params=params)
         spreadsheet_id = r.json()["id"]
         return self.open_by_key(spreadsheet_id)
 
@@ -353,12 +356,14 @@ class Client:
                 comments.extend(res["comments"])
                 page_token = res.get("nextPageToken", None)
 
-            destination_url = DRIVE_FILES_API_V3_COMMENTS_URL % (new_spreadsheet.id)
+            destination_url = DRIVE_FILES_API_V3_COMMENTS_URL % (
+                new_spreadsheet.id)
             # requesting some fields in the response is mandatory from the API.
             # choose 'id' randomly out of all the fields, but no need to use it for now.
             params = {"fields": "id"}
             for comment in comments:
-                self.request("post", destination_url, json=comment, params=params)
+                self.request("post", destination_url,
+                             json=comment, params=params)
 
         return new_spreadsheet
 
@@ -533,6 +538,11 @@ class BackoffClient(Client):
         Use it at your own risk !
 
     .. note::
+        To use with the `auth` module, make sure to pass this backoff
+        client factory using the ``client_factory`` parameter of the
+        method used.
+
+    .. note::
         Currently known issues are:
 
         * will retry exponentially even when the error should
@@ -579,3 +589,6 @@ class BackoffClient(Client):
 
             # failed too many times, raise APIEerror
             raise err
+
+
+ClientFactory = Type[Client]

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -55,8 +55,7 @@ class Client:
 
         self.auth.refresh(Request(self.session))
 
-        self.session.headers.update(
-            {"Authorization": "Bearer %s" % self.auth.token})
+        self.session.headers.update({"Authorization": "Bearer %s" % self.auth.token})
 
     def set_timeout(self, timeout):
         """How long to wait for the server to send
@@ -226,8 +225,7 @@ class Client:
         if folder_id is not None:
             payload["parents"] = [folder_id]
 
-        r = self.request("post", DRIVE_FILES_API_V3_URL,
-                         json=payload, params=params)
+        r = self.request("post", DRIVE_FILES_API_V3_URL, json=payload, params=params)
         spreadsheet_id = r.json()["id"]
         return self.open_by_key(spreadsheet_id)
 
@@ -356,14 +354,12 @@ class Client:
                 comments.extend(res["comments"])
                 page_token = res.get("nextPageToken", None)
 
-            destination_url = DRIVE_FILES_API_V3_COMMENTS_URL % (
-                new_spreadsheet.id)
+            destination_url = DRIVE_FILES_API_V3_COMMENTS_URL % (new_spreadsheet.id)
             # requesting some fields in the response is mandatory from the API.
             # choose 'id' randomly out of all the fields, but no need to use it for now.
             params = {"fields": "id"}
             for comment in comments:
-                self.request("post", destination_url,
-                             json=comment, params=params)
+                self.request("post", destination_url, json=comment, params=params)
 
         return new_spreadsheet
 


### PR DESCRIPTION
This is a pull request to implement a documented feature described in https://github.com/burnash/gspread/issues/1074

I have reviewed the submitting guidelines and I believe this follows all guidelines. (The exception is that it does not provide coverage: However unless I am mistaken there seems to be no tests for this functionality yet, and while this is a noble project, it's not the focus of this pull-request 😁 This feature is passive, it introduces no functionality, it is just a conduit to use the existing `gspread.client.BackoffClient`). Happy to make any modification necessary!

**Is your feature request related to a problem? Please describe.**
As noted, Google introduced [usage limits](https://developers.google.com/sheets/api/limits). While the behavior seems to not be well defined everywhere (in Drive API, the quota limit return 403 apparently undistinguishable by error code of an auth problem, for instance), in Sheets API the rate limit issue consistently returns 429. The existing `gspread.client.BackoffClient` class deals with this problem elegantly and effectively, and at the cost for the developer of one line change. Unfortunately the `auth` methods use `gspread.client.Client()` internally, in a hard-coded fashion.

**Describe the solution you'd like**
The feature introduces a parameter that is retrocompatible, as it defaults to the current behavior, but it also enables use of the `gspread.client.BackoffClient`.

**Describe alternatives you've considered**
- Modifying my local copy of the package only
- Catching the error at the higher level of my own code, but that seems sub-optimal, as it requires much more error catching code

**Additional context**
This is a small tweak, that is fully documented, that allows for better use of existing functionality of this package.