### PR TITLE
Fix `list_protected_ranges`

### DIFF
--- a/gspread/spreadsheet.py
+++ b/gspread/spreadsheet.py
@@ -724,6 +724,7 @@ class Spreadsheet:
                 lambda sheet: sheet["properties"]["sheetId"] == sheetid, sheets
             )
 
-            return sheet["protectedRanges"]
-        except (StopIteration, KeyError):
-            return []
+        except StopIteration:
+            raise WorksheetNotFound("worksheet id {} not found".format(sheetid))
+
+        return sheet.get("protectedRanges", [])


### PR DESCRIPTION
when listing all the protected ranges of a worksheet, if the
`sheetid` does not exists, do not return an empty list.
Instead raise an exception as the ID is wrong.

If the ID is correct try to extract the protected ranges if empty
return an empty list.

closes #1050