### PR TITLE
Add function to convert column letter to column index

### DIFF
--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -6,6 +6,7 @@ Exceptions
 .. autoexception:: gspread.exceptions.CellNotFound
 .. autoexception:: gspread.exceptions.GSpreadException
 .. autoexception:: gspread.exceptions.IncorrectCellLabel
+.. autoexception:: gspread.exceptions.InvalidInputValue
 .. autoexception:: gspread.exceptions.NoValidUrlKeyFound
 .. autoexception:: gspread.exceptions.SpreadsheetNotFound
 .. autoexception:: gspread.exceptions.UnSupportedExportFormat

--- a/gspread/exceptions.py
+++ b/gspread/exceptions.py
@@ -35,6 +35,10 @@ class IncorrectCellLabel(GSpreadException):
     """The cell label is incorrect."""
 
 
+class InvalidInputValue(GSpreadException):
+    """The provided values is incorrect."""
+
+
 class APIError(GSpreadException):
     def __init__(self, response):
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -23,7 +23,7 @@ from google.auth.credentials import Credentials as Credentials
 from google.oauth2.credentials import Credentials as UserCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 
-from .exceptions import IncorrectCellLabel, NoValidUrlKeyFound
+from .exceptions import IncorrectCellLabel, InvalidInputValue, NoValidUrlKeyFound
 
 MAGIC_NUMBER = 64
 CELL_ADDR_RE = re.compile(r"([A-Za-z]+)([1-9]\d*)")
@@ -412,6 +412,24 @@ def a1_range_to_grid_range(name, sheet_id=None):
         grid_range["sheetId"] = sheet_id
 
     return grid_range
+
+
+def column_letter_to_index(column):
+    try:
+        (_, index) = _a1_to_rowcol_unbounded(column)
+    except IncorrectCellLabel:
+        # make it coherent and raise the same exception in case of any error
+        # from user input value
+        raise InvalidInputValue(
+            "invalid value: {}, must be a column letter".format(column)
+        )
+
+    if index is inf:
+        raise InvalidInputValue(
+            "invalid value: {}, must be a column letter".format(column)
+        )
+
+    return index
 
 
 def cast_to_a1_notation(method):

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -8,12 +8,10 @@ This module contains utility functions.
 
 import re
 from collections import defaultdict, namedtuple
-from functools import wraps
-from math import inf
-
 from collections.abc import Sequence
-
+from functools import wraps
 from itertools import chain
+from math import inf
 from urllib.parse import quote as uquote
 
 from google.auth.credentials import Credentials as Credentials

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -11,10 +11,7 @@ from collections import defaultdict, namedtuple
 from functools import wraps
 from math import inf
 
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
+from collections.abc import Sequence
 
 from itertools import chain
 from urllib.parse import quote as uquote

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -415,6 +415,30 @@ def a1_range_to_grid_range(name, sheet_id=None):
 
 
 def column_letter_to_index(column):
+    """Converts a column letter to its numerical index.
+
+    This is useful when using the method :meth:`gspread.worksheet.Worksheet.col_values`.
+    Which requires a column index.
+
+    This function is case-insensitive.
+
+    Raises :exc:`gspread.exceptions.InvalidInputValue` in case of invalid input.
+
+    Examples::
+
+        >>> column_letter_to_index("a")
+        1
+
+    >>> column_letter_to_index("A")
+    1
+
+    >>> column_letter_to_index("AZ")
+    52
+
+    >>> column_letter_to_index("!@#$%^&")
+    ...
+    gspread.exceptions.InvalidInputValue: invalid value: !@#$%^&, must be a column letter
+    """
     try:
         (_, index) = _a1_to_rowcol_unbounded(column)
     except IncorrectCellLabel:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -169,3 +169,35 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(from_top_left, from_bottom_right)
         self.assertEqual(from_top_left, from_bottom_left)
         self.assertEqual(from_top_left, from_top_right)
+
+    def test_column_letter_to_index(self):
+        # All the input values to test one after an other
+        # [0] input value
+        # [1] expected return value
+        # [2] expected exception to raise
+        inputs = [
+            ("", None, gspread.exceptions.InvalidInputValue),
+            ("A", 1, None),
+            ("Z", 26, None),
+            ("AA", 27, None),
+            ("AAA", 703, None),
+            ("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 256094574536617744129141650397448476, None),
+            ("!@#$%^&*()", None, gspread.exceptions.InvalidInputValue),
+        ]
+
+        for label, expected, exception in inputs:
+            if exception is not None:
+
+                # assert the exception is raised
+                with self.assertRaises(exception):
+                    utils.column_letter_to_index(label)
+            else:
+                # assert the return values is correct
+                result = utils.column_letter_to_index(label)
+                self.assertEqual(
+                    result,
+                    expected,
+                    "could not convert column letter '{}' to the right value '{}".format(
+                        label, expected
+                    ),
+                )


### PR DESCRIPTION
Add a new method to convert the letter identifying a column
into its index.

This allows users to use the method `Worksheet.col_values` using
a letter to identify the column but passing through this new method
allows to safely convert it to the right index.

closes #1073