### PR TITLE
Fix function `numericise_all`

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -182,16 +182,16 @@ def numericise(
 
 
 def numericise_all(
-    input,
+    values,
     empty2zero=False,
     default_blank="",
     allow_underscores_in_numeric_literals=False,
-    ignore=None,
+    ignore=[],
 ):
     """Returns a list of numericised values from strings except those from the
     row specified as ignore.
 
-    :param list input: Input row
+    :param list values: Input row
     :param bool empty2zero: (optional) Whether or not to return empty cells
         as 0 (zero). Defaults to ``False``.
     :param str default_blank: Which value to use for blank cells,
@@ -201,18 +201,18 @@ def numericise_all(
     :param list ignore: List of ints of indices of the row (index 1) to ignore
         numericising.
     """
-    ignored_rows = [input[x - 1] for x in (ignore or [])]
     numericised_list = [
-        s
-        if s in ignored_rows
+        values[index]
+        if index + 1 in ignore
         else numericise(
-            s,
+            values[index],
             empty2zero=empty2zero,
             default_blank=default_blank,
             allow_underscores_in_numeric_literals=allow_underscores_in_numeric_literals,
         )
-        for s in input
+        for index in range(len(values))
     ]
+
     return numericised_list
 
 

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -428,7 +428,7 @@ class Worksheet:
         head=1,
         default_blank="",
         allow_underscores_in_numeric_literals=False,
-        numericise_ignore=None,
+        numericise_ignore=[],
         value_render_option=None,
         expected_headers=None,
     ):
@@ -449,7 +449,7 @@ class Worksheet:
         :param bool allow_underscores_in_numeric_literals: (optional) Allow
             underscores in numeric literals, as introduced in PEP 515
         :param list numericise_ignore: (optional) List of ints of indices of
-            the row (starting at 1) to ignore numericising, special use
+            the columns (starting at 1) to ignore numericising, special use
             of ['all'] to ignore numericising on all columns.
         :param str value_render_option: (optional) Determines how values should
             be rendered in the the output. See `ValueRenderOption`_ in

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -78,6 +78,21 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(utils.numericise(""), "")
         self.assertEqual(utils.numericise(None), None)
 
+        # test numericise_all
+        inputs = ["1", "2", "3"]
+        expected = [1, 2, 3]
+        self.assertEqual(utils.numericise_all(inputs), expected)
+
+        # skip non digit values
+        inputs + ["a"]
+        expected + ["a"]
+        self.assertEqual(utils.numericise_all(inputs), expected)
+
+        # skip ignored columns
+        inputs + ["5", "5"]
+        expected + ["5", 5]
+        self.assertEqual(utils.numericise_all(inputs, ignore=[5]), expected)
+
     def test_a1_to_grid_range_simple(self):
         expected_single_dimension = {
             "startRowIndex": 0,


### PR DESCRIPTION
Function `numericise_all` can ignore some columns
and skip the value at that specific index.

previously used to
1. get the values to ignore on that row
2. iterate over each value of the row
3. if the value is in the list of ignoring values skip it.

Issue: if a row contains twice the same value and the user would like
to ignore one of the two then the other one is ignored too.

Instead use the index to compare if the value at that index should
be skipped or not.

Closes #1069