### PR TITLE
inherit_from_before option for insert_row/insert_rows

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1355,17 +1355,23 @@ class Worksheet:
             should be interpreted. Possible values are ``ValueInputOption.raw``
             or ``ValueInputOption.user_entered``.
             See `ValueInputOption`_ in the Sheets API.
-
-        .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
         :param bool inherit_from_before: (optional) If True, the new row will
             inherit its properties from the previous row. Defaults to False,
             meaning that the new row acquires the properties of the row
-            immediately after it. This cannot be True if the row being added is
-            at the top of the sheet (i.e. index=1).
+            immediately after it.
+            .. warning::
+               `inherit_from_before` must be False when adding a row to the top
+               of a spreadsheet (`index=1`), and must be True when adding to
+               the bottom of the spreadsheet.
+
+        .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
         """
-        return self.insert_rows([values], index,
-                                value_input_option=value_input_option,
-                                inherit_from_before=inherit_from_before)
+        return self.insert_rows(
+            [values],
+            index,
+            value_input_option=value_input_option,
+            inherit_from_before=inherit_from_before,
+        )
 
     def insert_rows(
         self,
@@ -1388,8 +1394,11 @@ class Worksheet:
         :param bool inherit_from_before: (optional) If true, new rows will
             inherit their properties from the previous row. Defaults to False,
             meaning that new rows acquire the properties of the row immediately
-            after them. This cannot be True if the rows being added are at the
-            top of the sheet (i.e. row=1).
+            after them.
+            .. warning::
+               `inherit_from_before` must be False when adding rows to the top
+               of a spreadsheet (`row=1`), and must be True when adding to
+               the bottom of the spreadsheet.
         """
 
         # can't insert row on sheet with colon ':'
@@ -1402,10 +1411,6 @@ class Worksheet:
         if inherit_from_before and row == 1:
             raise GSpreadException(
                 "inherit_from_before cannot be used when inserting row(s) at the top of a spreadsheet"
-            )
-        if not inherit_from_before and row == self.row_count + 1:
-            raise GSpreadException(
-                "inherit_from_before must be set to True when inserting row(s) at the bottom of a spreadsheet"
             )
 
         body = {
@@ -1455,8 +1460,12 @@ class Worksheet:
         :param bool inherit_from_before: (optional) If True, new columns will
             inherit their properties from the previous column. Defaults to
             False, meaning that new columns acquire the properties of the
-            column immediately after them. This cannot be True if the columns
-            being added are at the left edge of the sheet (i.e. col=1).
+            column immediately after them.
+
+            .. warning::
+               `inherit_from_before` must be False if adding at the left edge
+               of a spreadsheet (`col=1`), and must be True if adding at the
+               right edge of the spreadsheet.
         """
 
         if inherit_from_before and col == 1:

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1359,7 +1359,9 @@ class Worksheet:
             inherit its properties from the previous row. Defaults to False,
             meaning that the new row acquires the properties of the row
             immediately after it.
+
             .. warning::
+
                `inherit_from_before` must be False when adding a row to the top
                of a spreadsheet (`index=1`), and must be True when adding to
                the bottom of the spreadsheet.
@@ -1395,7 +1397,9 @@ class Worksheet:
             inherit their properties from the previous row. Defaults to False,
             meaning that new rows acquire the properties of the row immediately
             after them.
+
             .. warning::
+
                `inherit_from_before` must be False when adding rows to the top
                of a spreadsheet (`row=1`), and must be True when adding to
                the bottom of the spreadsheet.
@@ -1463,6 +1467,7 @@ class Worksheet:
             column immediately after them.
 
             .. warning::
+
                `inherit_from_before` must be False if adding at the left edge
                of a spreadsheet (`col=1`), and must be True if adding at the
                right edge of the spreadsheet.

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1337,7 +1337,13 @@ class Worksheet:
 
         return self.spreadsheet.values_append(range_label, params, body)
 
-    def insert_row(self, values, index=1, value_input_option=ValueInputOption.raw):
+    def insert_row(
+        self,
+        values,
+        index=1,
+        value_input_option=ValueInputOption.raw,
+        inherit_from_before=False,
+    ):
         """Adds a row to the worksheet at the specified index and populates it
         with values.
 
@@ -1351,8 +1357,14 @@ class Worksheet:
             See `ValueInputOption`_ in the Sheets API.
 
         .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
+        :param bool inherit_from_before: (optional) If true, the new row will
+            inherit its properties from the previous row. Defaults to False,
+            meaning that the new row acquires the properties of the row
+            immediately after it.
         """
-        return self.insert_rows([values], index, value_input_option=value_input_option)
+        return self.insert_rows([values], index,
+                                value_input_option=value_input_option,
+                                inherit_from_before=inherit_from_before)
 
     def insert_rows(
         self,

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1397,6 +1397,15 @@ class Worksheet:
                 "can't insert row in worksheet with colon ':' in its name. See issue: https://issuetracker.google.com/issues/36761154"
             )
 
+        if inherit_from_before and row == 1:
+            raise GSpreadException(
+                "inherit_from_before cannot be used when inserting row(s) at the top of a spreadsheet"
+            )
+        if not inherit_from_before and row == self.row_count + 1:
+            raise GSpreadException(
+                "inherit_from_before must be set to True when inserting row(s) at the bottom of a spreadsheet"
+            )
+
         body = {
             "requests": [
                 {

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1357,10 +1357,11 @@ class Worksheet:
             See `ValueInputOption`_ in the Sheets API.
 
         .. _ValueInputOption: https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
-        :param bool inherit_from_before: (optional) If true, the new row will
+        :param bool inherit_from_before: (optional) If True, the new row will
             inherit its properties from the previous row. Defaults to False,
             meaning that the new row acquires the properties of the row
-            immediately after it.
+            immediately after it. This cannot be True if the row being added is
+            at the top of the sheet (i.e. index=1).
         """
         return self.insert_rows([values], index,
                                 value_input_option=value_input_option,
@@ -1387,7 +1388,8 @@ class Worksheet:
         :param bool inherit_from_before: (optional) If true, new rows will
             inherit their properties from the previous row. Defaults to False,
             meaning that new rows acquire the properties of the row immediately
-            after them.
+            after them. This cannot be True if the rows being added are at the
+            top of the sheet (i.e. row=1).
         """
 
         # can't insert row on sheet with colon ':'
@@ -1450,10 +1452,11 @@ class Worksheet:
             should be interpreted. Possible values are ``ValueInputOption.raw``
             or ``ValueInputOption.user_entered``.
             See `ValueInputOption`_ in the Sheets API.
-        :param bool inherit_from_before: (optional) If true, tells the API to
-            give the new columns the same properties as the prior column; otherwise
-            the default behavior is that the new columns acquire the properties
-            of those that follow them
+        :param bool inherit_from_before: (optional) If True, new columns will
+            inherit their properties from the previous column. Defaults to
+            False, meaning that new columns acquire the properties of the
+            column immediately after them. This cannot be True if the columns
+            being added are at the left edge of the sheet (i.e. col=1).
         """
 
         if inherit_from_before and col == 1:

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1372,10 +1372,10 @@ class Worksheet:
             should be interpreted. Possible values are ``ValueInputOption.raw``
             or ``ValueInputOption.user_entered``.
             See `ValueInputOption`_ in the Sheets API.
-        :param bool inherit_from_before: (optional) If true, tells the API to
-            give the new rows the same properties as the prior row; otherwise
-            the default behavior is that the new rows acquire the properties
-            of those that follow them
+        :param bool inherit_from_before: (optional) If true, new rows will
+            inherit their properties from the previous row. Defaults to False,
+            meaning that new rows acquire the properties of the row immediately
+            after them.
         """
 
         # can't insert row on sheet with colon ':'

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1354,7 +1354,13 @@ class Worksheet:
         """
         return self.insert_rows([values], index, value_input_option=value_input_option)
 
-    def insert_rows(self, values, row=1, value_input_option=ValueInputOption.raw):
+    def insert_rows(
+        self,
+        values,
+        row=1,
+        value_input_option=ValueInputOption.raw,
+        inherit_from_before=False,
+    ):
         """Adds multiple rows to the worksheet at the specified index and
         populates them with values.
 
@@ -1366,6 +1372,10 @@ class Worksheet:
             should be interpreted. Possible values are ``ValueInputOption.raw``
             or ``ValueInputOption.user_entered``.
             See `ValueInputOption`_ in the Sheets API.
+        :param bool inherit_from_before: (optional) If true, tells the API to
+            give the new rows the same properties as the prior row; otherwise
+            the default behavior is that the new rows acquire the properties
+            of those that follow them
         """
 
         # can't insert row on sheet with colon ':'
@@ -1384,7 +1394,8 @@ class Worksheet:
                             "dimension": Dimension.rows,
                             "startIndex": row - 1,
                             "endIndex": len(values) + row - 1,
-                        }
+                        },
+                        "inheritFromBefore": inherit_from_before,
                     }
                 }
             ]
@@ -1400,7 +1411,13 @@ class Worksheet:
 
         return self.spreadsheet.values_append(range_label, params, body)
 
-    def insert_cols(self, values, col=1, value_input_option=ValueInputOption.raw):
+    def insert_cols(
+        self,
+        values,
+        col=1,
+        value_input_option=ValueInputOption.raw,
+        inherit_from_before=False,
+    ):
         """Adds multiple new cols to the worksheet at specified index and
         populates them with values.
 
@@ -1412,6 +1429,10 @@ class Worksheet:
             should be interpreted. Possible values are ``ValueInputOption.raw``
             or ``ValueInputOption.user_entered``.
             See `ValueInputOption`_ in the Sheets API.
+        :param bool inherit_from_before: (optional) If true, tells the API to
+            give the new columns the same properties as the prior column; otherwise
+            the default behavior is that the new columns acquire the properties
+            of those that follow them
         """
         body = {
             "requests": [
@@ -1422,7 +1443,8 @@ class Worksheet:
                             "dimension": Dimension.cols,
                             "startIndex": col - 1,
                             "endIndex": len(values) + col - 1,
-                        }
+                        },
+                        "inheritFromBefore": inherit_from_before,
                     }
                 }
             ]

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1455,6 +1455,12 @@ class Worksheet:
             the default behavior is that the new columns acquire the properties
             of those that follow them
         """
+
+        if inherit_from_before and col == 1:
+            raise GSpreadException(
+                "inherit_from_before cannot be used when inserting column(s) at the left edge of a spreadsheet"
+            )
+
         body = {
             "requests": [
                 {

--- a/tests/cassettes/WorksheetTest.test_insert_row.json
+++ b/tests/cassettes/WorksheetTest.test_insert_row.json
@@ -448,7 +448,7 @@
             "request": {
                 "method": "POST",
                 "uri": "https://sheets.googleapis.com/v4/spreadsheets/1ij8FSXamZqVkz9G8W2HtTsF9DrrMuXxxLX6sHTXipXs:batchUpdate",
-                "body": "{\"requests\": [{\"insertDimension\": {\"range\": {\"sheetId\": 0, \"dimension\": \"ROWS\", \"startIndex\": 1, \"endIndex\": 2}}}]}",
+                "body": "{\"requests\": [{\"insertDimension\": {\"range\": {\"sheetId\": 0, \"dimension\": \"ROWS\", \"startIndex\": 1, \"endIndex\": 2}, \"inheritFromBefore\": false}}]}",
                 "headers": {
                     "User-Agent": [
                         "python-requests/2.27.1"
@@ -746,7 +746,7 @@
             "request": {
                 "method": "POST",
                 "uri": "https://sheets.googleapis.com/v4/spreadsheets/1ij8FSXamZqVkz9G8W2HtTsF9DrrMuXxxLX6sHTXipXs:batchUpdate",
-                "body": "{\"requests\": [{\"insertDimension\": {\"range\": {\"sheetId\": 0, \"dimension\": \"ROWS\", \"startIndex\": 0, \"endIndex\": 1}}}]}",
+                "body": "{\"requests\": [{\"insertDimension\": {\"range\": {\"sheetId\": 0, \"dimension\": \"ROWS\", \"startIndex\": 0, \"endIndex\": 1}, \"inheritFromBefore\": false}}]}",
                 "headers": {
                     "User-Agent": [
                         "python-requests/2.27.1"

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -754,11 +754,7 @@ class WorksheetTest(GspreadTest):
 
         new_row_values = [next(sg) for i in range(num_cols + 4)]
         with pytest.raises(GSpreadException):
-            self.sheet.insert_row(new_row_values, 1,
-                                  inherit_from_before=True)
-        with pytest.raises(GSpreadException):
-            self.sheet.insert_row(new_row_values, self.sheet.row_count + 1,
-                                  inherit_from_before=False)
+            self.sheet.insert_row(new_row_values, 1, inherit_from_before=True)
 
     @pytest.mark.vcr()
     def test_delete_row(self):

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -752,6 +752,14 @@ class WorksheetTest(GspreadTest):
         b3 = self.sheet.acell("B3", value_render_option=utils.ValueRenderOption.formula)
         self.assertEqual(b3.value, formula)
 
+        new_row_values = [next(sg) for i in range(num_cols + 4)]
+        with pytest.raises(GSpreadException):
+            self.sheet.insert_row(new_row_values, 1,
+                                  inherit_from_before=True)
+        with pytest.raises(GSpreadException):
+            self.sheet.insert_row(new_row_values, self.sheet.row_count + 1,
+                                  inherit_from_before=False)
+
     @pytest.mark.vcr()
     def test_delete_row(self):
         sg = self._sequence_generator()


### PR DESCRIPTION
(see also: pr #1079, closes #1091)

Hi! I've gone ahead and done up the code.

As for tests, I'm not entirely sure what to do, since I understand there's no way to access the properties of a sheet, which means here's no way to check whether the properties were correctly inherited from the desired row (correct me if I'm wrong). So I simply added some tests to check the behaviour when called with different indices (i.e. check that an exception is being thrown with invalid combos of `inherit_from_before` and row index).