### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -281,7 +281,7 @@ epub_copyright = "%s, Anton Burnashev" % date.today().year
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -226,7 +226,7 @@ Clear one or multiple celle ranges at once:
 
    worksheet.batch_clear(["A1:B1", "C2:E2", "my_named_range"])
 
-Clear the entire workshseet:
+Clear the entire worksheet:
 
 .. code:: python
 

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -1021,7 +1021,7 @@ class WorksheetTest(GspreadTest):
         # we can only check the result of `auto_resize_columns`
         # using only code and the API.
         # To test `auto_resize_row` we must use a web browser and
-        # force the size of a row then auto resize it using gpsread.
+        # force the size of a row then auto resize it using gspread.
 
         # insert enough text to make it larger than the column
         w.update_acell("A1", "A" * 1024)


### PR DESCRIPTION
There are small typos in:
- docs/conf.py
- docs/user-guide.rst
- tests/worksheet_test.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `worksheet` rather than `workshseet`.
- Should read `gspread` rather than `gpsread`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md