### PR TITLE
Fix typo in `Worksheet.batch_format` method

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -963,7 +963,7 @@ class Worksheet:
                     },
                 },
             ]
-            worksheet.batch_update(formats)
+            worksheet.batch_format(formats)
 
         .. versionadded:: 5.4
         """


### PR DESCRIPTION
closes #1100