### PR TITLE
Fix `clear_note` method when using numeric boundaries

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -2060,19 +2060,13 @@ class Worksheet:
         if not isinstance(content, str):
             raise TypeError("Only string allowed as content for a note.")
 
-        (startRow, startColumn) = a1_to_rowcol(cell)
+        grid_range = a1_range_to_grid_range(cell, self.id)
 
         body = {
             "requests": [
                 {
                     "updateCells": {
-                        "range": {
-                            "sheetId": self.id,
-                            "startRowIndex": startRow - 1,
-                            "endRowIndex": startRow,
-                            "startColumnIndex": startColumn - 1,
-                            "endColumnIndex": startColumn,
-                        },
+                        "range": grid_range,
                         "rows": [{"values": [{"note": content}]}],
                         "fields": "note",
                     }


### PR DESCRIPTION
when using numeric boundaries, extract the full given range
and not just the top left corner.
This allows a user to set/update/clear a complete range.

closes #1103