### PR TITLE
Fix a typo in the permissions:create API payload

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -500,7 +500,7 @@ class Client:
         }
 
         params = {
-            "sendNotificationEmails": notify,
+            "sendNotificationEmail": notify,
             "emailMessage": email_message,
             "supportsAllDrives": "true",
         }


### PR DESCRIPTION
There is a typo in the permissions:create API payload. As in the [drive API v3 documentation](https://developers.google.com/drive/api/v3/reference/permissions/create), the payload should be _sendNotificationEmail_ instead of _sendNotificationEmails_. As a result, the API call would always send a notification email to the share person, even a False has been passed in method parameter notify.