### PR TITLE
Return created permission on `Spreadsheet.share()`

### DIFF
--- a/gspread/spreadsheet.py
+++ b/gspread/spreadsheet.py
@@ -509,7 +509,7 @@ class Spreadsheet:
             # Give Otto's family a read permission on this spreadsheet
             sh.share('otto-familly@example.com', perm_type='group', role='reader')
         """
-        self.client.insert_permission(
+        return self.client.insert_permission(
             self.id,
             value=email_address,
             perm_type=perm_type,


### PR DESCRIPTION
When using the method `Spreadsheet.share()` return the newly created permission so user don't have to list the permissions to get it.

closes #1109