### PR TITLE
Fix sendNotificationEmail API parameter

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -500,7 +500,7 @@ class Client:
         }
 
         params = {
-            "sendNotificationEmail": notify,
+            "sendNotificationEmails": notify,
             "emailMessage": email_message,
             "supportsAllDrives": "true",
         }


### PR DESCRIPTION
## Bug description:

The spreadsheet `share` [method](https://docs.gspread.org/en/latest/api/models/spreadsheet.html?highlight=share#gspread.spreadsheet.Spreadsheet.share) sends notification emails even when the `notify` parameter is passed as `False`.

## Solution:

In the API call, `sendNotificationEmail` is the parameter name currently being used. The correct parameter name is `sendNotificationEmails` (plural). See https://developers.google.com/drive/api/v2/reference/permissions/insert#parameters