### PR TITLE
(fixed #1113) Supply correct Google API v3 permission for domains

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -491,19 +491,25 @@ class Client:
         """
 
         url = "{}/{}/permissions".format(DRIVE_FILES_API_V3_URL, file_id)
-
         payload = {
-            "emailAddress": value,
             "type": perm_type,
             "role": role,
             "withLink": with_link,
         }
-
         params = {
-            "sendNotificationEmail": notify,
-            "emailMessage": email_message,
             "supportsAllDrives": "true",
         }
+
+        if perm_type == "domain":
+            payload["domain"] = value
+        elif perm_type in {"user", "group"}:
+            payload["emailAddress"] = value
+            params["sendNotificationEmail"] = notify
+            params["emailMessage"] = email_message
+        elif perm_type == "anyone":
+            pass
+        else:
+            raise ValueError("Invalid permission type: {}".format(perm_type))
 
         return self.request("post", url, json=payload, params=params)
 


### PR DESCRIPTION
closes #1113

I didn't add any tests as I took a look at the current test code and it looked like more than I wanted to get into. Probably they should get added, but if someone feels more qualified then they can start off of this commit.

Without this change, my client code of `sheet.share(DOMAIN, perm_type="domain", role="writer")` fails. With this change, my client code works.