### PR TITLE
Bugfix/numericese all

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -201,6 +201,9 @@ def numericise_all(
     :param list ignore: List of ints of indices of the row (index 1) to ignore
         numericising.
     """
+    # in case someone explicitly passes `None` as ignored list
+    ignore = ignore or []
+
     numericised_list = [
         values[index]
         if index + 1 in ignore

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
 bandit==1.7.0
 black==22.3.0
 codespell==2.1.0
-flake8==3.9.2
+flake8==5.0.4
 isort==5.9.3

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -93,6 +93,9 @@ class UtilsTest(unittest.TestCase):
         expected + ["5", 5]
         self.assertEqual(utils.numericise_all(inputs, ignore=[5]), expected)
 
+        # provide explicit `None` as ignored list
+        self.assertEqual(utils.numericise_all(inputs, ignore=None), expected)
+
     def test_a1_to_grid_range_simple(self):
         expected_single_dimension = {
             "startRowIndex": 0,


### PR DESCRIPTION
Prevent crash when passing `None` to `numericise_all`

When a user passes `None` as a list to ignore to the function
`numericise_all` it crashes because it tries to iterate over the list.
cover that case be setting the ignored list to an empty list if not set.

Later solution will be to add typing to this project.

closes #1118