### PR TITLE
update parent forlder for `client.copy` method

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -312,7 +312,7 @@ class Client:
         }
 
         if folder_id is not None:
-            payload["parents"] = [{"id": folder_id}]
+            payload["parents"] = [folder_id]
 
         params = {"supportsAllDrives": True}
         r = self.request("post", url, json=payload, params=params)


### PR DESCRIPTION
closes #1121