### PR TITLE
Fix dependencies required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     maintainer_email="lavigne958@gmail.com",
     url="https://github.com/burnash/gspread",
     keywords=["spreadsheets", "google-spreadsheets"],
-    install_requires=["google-auth==1.12.0", "google-auth-oauthlib==0.5.3"],
+    install_requires=["google-auth>=1.12.0", "google-auth-oauthlib>=0.4.1"],
     python_requires=">=3.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         "Programming Language :: Python",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-google-auth==1.12.0
-google-auth-oauthlib==0.5.3
+google-auth>=1.12.0
+google-auth-oauthlib>=0.4.1
 vcrpy
 pytest
 pytest-vcr


### PR DESCRIPTION
do not require a specific version of `google-auth` and `google-auth-oauthlib`. keep the same minimum version required like before, this works fine. If needed, pip can resolve the dependencies and use more recent versions, they will work fine too, it has been tested.

Previously when encountered dependency version issue it was due to `google-auth-oauthlib` that required a new import from `google-auth` but did not raise its own minimum required version.

Now that it has been fixed on their side we don't have any more issues.

closes #1145 