### PR TITLE
Fix: `hidden` property might not be set from the API

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -144,7 +144,8 @@ class Worksheet:
     @property
     def isSheetHidden(self):
         """Worksheet hidden status."""
-        return self._properties["hidden"]
+        # if the property is not set then hidden=False
+        return self._properties.get("hidden", False)
 
     @property
     def updated(self):


### PR DESCRIPTION
If the property is not set then it means its value is `False`.

closes #1149