### PR TITLE
Handle cases when rgbColor is not set

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -191,9 +191,7 @@ class Worksheet:
     @property
     def tab_color(self):
         """Tab color style."""
-        if "tabColorStyle" in self._properties:
-            return self._properties["tabColorStyle"]["rgbColor"]
-        return None
+        return self._properties.get("tabColorStyle", {}).get("rgbColor", None)
 
     def _get_sheet_property(self, property, default_value):
         """return a property of this worksheet or default value if not found"""


### PR DESCRIPTION
closes #1167 

I did not add a new exception, simply fix the code to return a consistent result if none of the values are set.