### PR TITLE
Spelling fix & update docs with date_time_render_option behaviour

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -34,7 +34,7 @@ ValueRenderOption = namedtuple(
 ValueInputOption = namedtuple("ValueInputOption", ["raw", "user_entered"])(
     "RAW", "USER_ENTERED"
 )
-DateTimeOption = namedtuple("DateTimeOption", ["serial_number", "formated_string"])(
+DateTimeOption = namedtuple("DateTimeOption", ["serial_number", "formatted_string"])(
     "SERIAL_NUMBER", "FORMATTED_STRING"
 )
 MimeType = namedtuple(

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -390,9 +390,9 @@ class Worksheet:
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
 
-            .. note::
+            .. warning::
 
-                This is ignored if ``value_render_option`` is ``ValueRenderOption.formatted``.
+                Setting this to anything while ``value_render_option`` is ``ValueRenderOption.formatted`` will throw an :exc:`~gspread.exceptions.APIError`.
 
             The default ``date_time_render_option`` is ``DateTimeOption.serial_number``.
         :type date_time_render_option: :namedtuple:`~gspread.utils.DateTimeOption`
@@ -596,9 +596,9 @@ class Worksheet:
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
 
-            .. note::
+            .. warning::
 
-                This is ignored if ``value_render_option`` is ``ValueRenderOption.formatted``.
+                Setting this to anything while ``value_render_option`` is ``ValueRenderOption.formatted`` will throw an :exc:`~gspread.exceptions.APIError`.
 
             The default ``date_time_render_option`` is ``DateTimeOption.serial_number``.
         :type date_time_render_option: :namedtuple:`~gspread.utils.DateTimeOption`
@@ -780,9 +780,9 @@ class Worksheet:
                  as strings in their given number format
                  (which depends on the spreadsheet locale).
 
-             .. note::
+             .. warning::
 
-                 This is ignored if ``value_render_option`` is ``ValueRenderOption.formatted``.
+                 Setting this to anything while ``value_render_option`` is ``ValueRenderOption.formatted`` will throw an :exc:`~gspread.exceptions.APIError`.
 
              The default ``date_time_render_option`` is ``DateTimeOption.serial_number``.
         :type date_time_render_option: :namedtuple:`~gspread.utils.DateTimeOption`
@@ -873,9 +873,9 @@ class Worksheet:
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
 
-            .. note::
+            .. warning::
 
-                This is ignored if ``value_render_option`` is ``ValueRenderOption.formatted``.
+                Setting this to anything while ``value_render_option`` is ``ValueRenderOption.formatted`` will throw an :exc:`~gspread.exceptions.APIError`.
 
             The default ``date_time_render_option`` is ``DateTimeOption.serial_number``.
         :type date_time_render_option: :namedtuple:`~gspread.utils.DateTimeOption`
@@ -982,7 +982,7 @@ class Worksheet:
 
             .. note::
 
-                This is ignored if ``value_render_option`` is ``ValueRenderOption.formatted``.
+                Setting this to anything while ``value_render_option`` is ``ValueRenderOption.formatted`` will throw an :exc:`~gspread.exceptions.APIError`.
 
             The default ``date_time_render_option`` is ``DateTimeOption.serial_number``.
         :type date_time_render_option: :namedtuple:`~gspread.utils.DateTimeOption`
@@ -1121,7 +1121,7 @@ class Worksheet:
 
             .. note::
 
-                This is ignored if ``value_render_option`` is ``ValueRenderOption.formatted``.
+                Setting this to anything while ``value_render_option`` is ``ValueRenderOption.formatted`` will throw an :exc:`~gspread.exceptions.APIError`.
 
             The default ``date_time_render_option`` is ``DateTimeOption.serial_number``.
         :type date_time_render_option: :namedtuple:`~gspread.utils.DateTimeOption`

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -385,7 +385,7 @@ class Worksheet:
                 to be output as doubles in "serial number" format,
                 as popularized by Lotus 1-2-3.
 
-            ``DateTimeOption.formated_string``
+            ``DateTimeOption.formatted_string``
                 Instructs date, time, datetime, and duration fields to be output
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
@@ -591,7 +591,7 @@ class Worksheet:
                 to be output as doubles in "serial number" format,
                 as popularized by Lotus 1-2-3.
 
-            ``DateTimeOption.formated_string``
+            ``DateTimeOption.formatted_string``
                 Instructs date, time, datetime, and duration fields to be output
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
@@ -775,7 +775,7 @@ class Worksheet:
                  to be output as doubles in "serial number" format,
                  as popularized by Lotus 1-2-3.
 
-             ``DateTimeOption.formated_string``
+             ``DateTimeOption.formatted_string``
                  Instructs date, time, datetime, and duration fields to be output
                  as strings in their given number format
                  (which depends on the spreadsheet locale).
@@ -868,7 +868,7 @@ class Worksheet:
                 to be output as doubles in "serial number" format,
                 as popularized by Lotus 1-2-3.
 
-            ``DateTimeOption.formated_string``
+            ``DateTimeOption.formatted_string``
                 Instructs date, time, datetime, and duration fields to be output
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
@@ -975,7 +975,7 @@ class Worksheet:
                 to be output as doubles in "serial number" format,
                 as popularized by Lotus 1-2-3.
 
-            ``DateTimeOption.formated_string``
+            ``DateTimeOption.formatted_string``
                 Instructs date, time, datetime, and duration fields to be output
                 as strings in their given number format
                 (which depends on the spreadsheet locale).
@@ -1114,7 +1114,7 @@ class Worksheet:
                 to be output as doubles in "serial number" format,
                 as popularized by Lotus 1-2-3.
 
-            ``DateTimeOption.formated_string``
+            ``DateTimeOption.formatted_string``
                 Instructs date, time, datetime, and duration fields to be output
                 as strings in their given number format
                 (which depends on the spreadsheet locale).

--- a/tests/cassettes/WorksheetTest.test_get_all_values_date_time_render_options.json
+++ b/tests/cassettes/WorksheetTest.test_get_all_values_date_time_render_options.json
@@ -1,0 +1,844 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://www.googleapis.com/drive/v3/files?supportsAllDrives=True",
+                "body": "{\"name\": \"Test WorksheetTest test_get_all_values_date_time_render_options\", \"mimeType\": \"application/vnd.google-apps.spreadsheet\"}",
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "130"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:54 GMT"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin, X-Origin"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Expires": [
+                        "Mon, 01 Jan 1990 00:00:00 GMT"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "217"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"kind\": \"drive#file\",\n  \"id\": \"1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8\",\n  \"name\": \"Test WorksheetTest test_get_all_values_date_time_render_options\",\n  \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8?includeGridData=false",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:55 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "3361"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"spreadsheetId\": \"1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8\",\n  \"properties\": {\n    \"title\": \"Test WorksheetTest test_get_all_values_date_time_render_options\",\n    \"locale\": \"en_US\",\n    \"autoRecalc\": \"ON_CHANGE\",\n    \"timeZone\": \"Etc/GMT\",\n    \"defaultFormat\": {\n      \"backgroundColor\": {\n        \"red\": 1,\n        \"green\": 1,\n        \"blue\": 1\n      },\n      \"padding\": {\n        \"top\": 2,\n        \"right\": 3,\n        \"bottom\": 2,\n        \"left\": 3\n      },\n      \"verticalAlignment\": \"BOTTOM\",\n      \"wrapStrategy\": \"OVERFLOW_CELL\",\n      \"textFormat\": {\n        \"foregroundColor\": {},\n        \"fontFamily\": \"arial,sans,sans-serif\",\n        \"fontSize\": 10,\n        \"bold\": false,\n        \"italic\": false,\n        \"strikethrough\": false,\n        \"underline\": false,\n        \"foregroundColorStyle\": {\n          \"rgbColor\": {}\n        }\n      },\n      \"backgroundColorStyle\": {\n        \"rgbColor\": {\n          \"red\": 1,\n          \"green\": 1,\n          \"blue\": 1\n        }\n      }\n    },\n    \"spreadsheetTheme\": {\n      \"primaryFontFamily\": \"Arial\",\n      \"themeColors\": [\n        {\n          \"colorType\": \"TEXT\",\n          \"color\": {\n            \"rgbColor\": {}\n          }\n        },\n        {\n          \"colorType\": \"BACKGROUND\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 1,\n              \"blue\": 1\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT1\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.25882354,\n              \"green\": 0.52156866,\n              \"blue\": 0.95686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT2\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.91764706,\n              \"green\": 0.2627451,\n              \"blue\": 0.20784314\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT3\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.9843137,\n              \"green\": 0.7372549,\n              \"blue\": 0.015686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT4\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.20392157,\n              \"green\": 0.65882355,\n              \"blue\": 0.3254902\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT5\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 0.42745098,\n              \"blue\": 0.003921569\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT6\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.27450982,\n              \"green\": 0.7411765,\n              \"blue\": 0.7764706\n            }\n          }\n        },\n        {\n          \"colorType\": \"LINK\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.06666667,\n              \"green\": 0.33333334,\n              \"blue\": 0.8\n            }\n          }\n        }\n      ]\n    }\n  },\n  \"sheets\": [\n    {\n      \"properties\": {\n        \"sheetId\": 0,\n        \"title\": \"Sheet1\",\n        \"index\": 0,\n        \"sheetType\": \"GRID\",\n        \"gridProperties\": {\n          \"rowCount\": 1000,\n          \"columnCount\": 26\n        }\n      }\n    }\n  ],\n  \"spreadsheetUrl\": \"https://docs.google.com/spreadsheets/d/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/edit\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8?includeGridData=false",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:55 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "3361"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"spreadsheetId\": \"1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8\",\n  \"properties\": {\n    \"title\": \"Test WorksheetTest test_get_all_values_date_time_render_options\",\n    \"locale\": \"en_US\",\n    \"autoRecalc\": \"ON_CHANGE\",\n    \"timeZone\": \"Etc/GMT\",\n    \"defaultFormat\": {\n      \"backgroundColor\": {\n        \"red\": 1,\n        \"green\": 1,\n        \"blue\": 1\n      },\n      \"padding\": {\n        \"top\": 2,\n        \"right\": 3,\n        \"bottom\": 2,\n        \"left\": 3\n      },\n      \"verticalAlignment\": \"BOTTOM\",\n      \"wrapStrategy\": \"OVERFLOW_CELL\",\n      \"textFormat\": {\n        \"foregroundColor\": {},\n        \"fontFamily\": \"arial,sans,sans-serif\",\n        \"fontSize\": 10,\n        \"bold\": false,\n        \"italic\": false,\n        \"strikethrough\": false,\n        \"underline\": false,\n        \"foregroundColorStyle\": {\n          \"rgbColor\": {}\n        }\n      },\n      \"backgroundColorStyle\": {\n        \"rgbColor\": {\n          \"red\": 1,\n          \"green\": 1,\n          \"blue\": 1\n        }\n      }\n    },\n    \"spreadsheetTheme\": {\n      \"primaryFontFamily\": \"Arial\",\n      \"themeColors\": [\n        {\n          \"colorType\": \"TEXT\",\n          \"color\": {\n            \"rgbColor\": {}\n          }\n        },\n        {\n          \"colorType\": \"BACKGROUND\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 1,\n              \"blue\": 1\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT1\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.25882354,\n              \"green\": 0.52156866,\n              \"blue\": 0.95686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT2\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.91764706,\n              \"green\": 0.2627451,\n              \"blue\": 0.20784314\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT3\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.9843137,\n              \"green\": 0.7372549,\n              \"blue\": 0.015686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT4\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.20392157,\n              \"green\": 0.65882355,\n              \"blue\": 0.3254902\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT5\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 0.42745098,\n              \"blue\": 0.003921569\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT6\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.27450982,\n              \"green\": 0.7411765,\n              \"blue\": 0.7764706\n            }\n          }\n        },\n        {\n          \"colorType\": \"LINK\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.06666667,\n              \"green\": 0.33333334,\n              \"blue\": 0.8\n            }\n          }\n        }\n      ]\n    }\n  },\n  \"sheets\": [\n    {\n      \"properties\": {\n        \"sheetId\": 0,\n        \"title\": \"Sheet1\",\n        \"index\": 0,\n        \"sheetType\": \"GRID\",\n        \"gridProperties\": {\n          \"rowCount\": 1000,\n          \"columnCount\": 26\n        }\n      }\n    }\n  ],\n  \"spreadsheetUrl\": \"https://docs.google.com/spreadsheets/d/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/edit\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27:clear",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:55 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "107"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"spreadsheetId\": \"1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8\",\n  \"clearedRange\": \"Sheet1!A1:Z1000\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8:batchUpdate",
+                "body": "{\"requests\": [{\"updateSheetProperties\": {\"properties\": {\"sheetId\": 0, \"gridProperties\": {\"rowCount\": 2, \"columnCount\": 4}}, \"fields\": \"gridProperties/rowCount,gridProperties/columnCount\"}}]}",
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "190"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:55 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "97"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"spreadsheetId\": \"1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8\",\n  \"replies\": [\n    {}\n  ]\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27%21A1%3AD2",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:56 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "58"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"range\": \"Sheet1!A1:D2\",\n  \"majorDimension\": \"ROWS\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "PUT",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27%21A1%3AD2?valueInputOption=USER_ENTERED",
+                "body": "{\"values\": [[\"=4/2\", \"2020-01-01\", \"string\", 53], [\"=3/2\", 0.12, \"1999-01-02\", \"\"]]}",
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "84"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:56 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "168"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"spreadsheetId\": \"1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8\",\n  \"updatedRange\": \"Sheet1!A1:D2\",\n  \"updatedRows\": 2,\n  \"updatedColumns\": 4,\n  \"updatedCells\": 8\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=SERIAL_NUMBER",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:56 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "184"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"range\": \"Sheet1!A1:D2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      2,\n      43831,\n      \"string\",\n      53\n    ],\n    [\n      1.5,\n      0.12,\n      36162\n    ]\n  ]\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27?valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:56 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "198"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"range\": \"Sheet1!A1:D2\",\n  \"majorDimension\": \"ROWS\",\n  \"values\": [\n    [\n      2,\n      \"2020-01-01\",\n      \"string\",\n      53\n    ],\n    [\n      1.5,\n      0.12,\n      \"1999-01-02\"\n    ]\n  ]\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "uri": "https://www.googleapis.com/drive/v3/files/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8?supportsAllDrives=True",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 204,
+                    "message": "No Content"
+                },
+                "headers": {
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Date": [
+                        "Sat, 06 May 2023 18:56:57 GMT"
+                    ],
+                    "Content-Type": [
+                        "text/html"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin, X-Origin"
+                    ],
+                    "Expires": [
+                        "Mon, 01 Jan 1990 00:00:00 GMT"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27?valueRenderOption=FORMATTED_VALUE&dateTimeRenderOption=SERIAL_NUMBER",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 404,
+                    "message": "Not Found"
+                },
+                "headers": {
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "Date": [
+                        "Sat, 06 May 2023 18:59:12 GMT"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "content-length": [
+                        "114"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"Requested entity was not found.\",\n    \"status\": \"NOT_FOUND\"\n  }\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/1yGp2hVaPh-D2AAbB-sZNeQu0DTjcYTAhfXHmOEY-I-8/values/%27Sheet1%27?valueRenderOption=FORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.30.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 404,
+                    "message": "Not Found"
+                },
+                "headers": {
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Date": [
+                        "Sat, 06 May 2023 19:11:05 GMT"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "content-length": [
+                        "114"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"Requested entity was not found.\",\n    \"status\": \"NOT_FOUND\"\n  }\n}\n"
+                }
+            }
+        }
+    ]
+}

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -530,7 +530,7 @@ class WorksheetTest(GspreadTest):
         expected_values = [
             [2, 43831, "string", 53],
             [3 / 2, 0.12, 36162, ""],
-            ]
+        ]
         self.assertEqual(read_records, expected_values)
 
         # with value_render as unformatted
@@ -542,7 +542,7 @@ class WorksheetTest(GspreadTest):
         expected_values = [
             [2, "2020-01-01", "string", 53],
             [3 / 2, 0.12, "1999-01-02", ""],
-            ]
+        ]
         self.assertEqual(read_records, expected_values)
 
         # with value_render as formatted (overrides date_time_render)
@@ -562,7 +562,6 @@ class WorksheetTest(GspreadTest):
                 value_render_option=utils.ValueRenderOption.formatted,
                 date_time_render_option=utils.DateTimeOption.formatted_string,
             )
-        
 
     @pytest.mark.vcr()
     def test_get_all_records(self):

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -507,6 +507,64 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(read_data, rows)
 
     @pytest.mark.vcr()
+    def test_get_all_values_date_time_render_options(self):
+        self.sheet.resize(2, 4)
+        # put in new values
+        rows = [
+            ["=4/2", "2020-01-01", "string", 53],
+            ["=3/2", 0.12, "1999-01-02", ""],
+        ]
+        cell_list = self.sheet.range("A1:D2")
+        for cell, value in zip(cell_list, itertools.chain(*rows)):
+            cell.value = value
+        self.sheet.update_cells(
+            cell_list, value_input_option=utils.ValueInputOption.user_entered
+        )
+
+        # with value_render as unformatted
+        # date_time_render as serial_number
+        read_records = self.sheet.get_values(
+            value_render_option=utils.ValueRenderOption.unformatted,
+            date_time_render_option=utils.DateTimeOption.serial_number,
+        )
+        expected_values = [
+            [2, 43831, "string", 53],
+            [3 / 2, 0.12, 36162, ""],
+            ]
+        self.assertEqual(read_records, expected_values)
+
+        # with value_render as unformatted
+        # date_time_render as formatted_string
+        read_records = self.sheet.get_values(
+            value_render_option=utils.ValueRenderOption.unformatted,
+            date_time_render_option=utils.DateTimeOption.formatted_string,
+        )
+        expected_values = [
+            [2, "2020-01-01", "string", 53],
+            [3 / 2, 0.12, "1999-01-02", ""],
+            ]
+        self.assertEqual(read_records, expected_values)
+
+        # with value_render as formatted (overrides date_time_render)
+        # date_time_render as serial_number
+        # CONFLICT - raises APIError 404 NOT_FOUND
+        with self.assertRaises(APIError):
+            read_records = self.sheet.get_values(
+                value_render_option=utils.ValueRenderOption.formatted,
+                date_time_render_option=utils.DateTimeOption.serial_number,
+            )
+
+        # with value_render as formatted (overrides date_time_render)
+        # date_time_render as formatted_string
+        # CONFLICT - raises APIError 404 NOT_FOUND
+        with self.assertRaises(APIError):
+            read_records = self.sheet.get_values(
+                value_render_option=utils.ValueRenderOption.formatted,
+                date_time_render_option=utils.DateTimeOption.formatted_string,
+            )
+        
+
+    @pytest.mark.vcr()
     def test_get_all_records(self):
         self.sheet.resize(4, 4)
         # put in new values


### PR DESCRIPTION
This started as a spelling change - I updated "formating" to "formatting for `gspread.utils.DateTimeOption`

I added a test for `date_time_render_option` as there did not seem to be one. I found that the conflict behaviour of this kwarg with `value_render_option` was different to how it was in the docs:

Docs:

![image](https://user-images.githubusercontent.com/13833017/236643467-cdfe88aa-fb5e-4062-bb1d-94ffe3395880.png)

Actual behaviour:

If both are set, and `value_render_option` is set to `ValueRenderOption.formatted`, then an API error is thrown by Google's API.

Thus, I have included this in the test, and updated the documentation to reflect this.

In summary:

- Fixed spelling `DateTimeOption.formated_string` -> `DateTimeOption.formated_string`
- Added test `test_get_all_values_date_time_render_options`
  - Added test cassette
- Updated documentation for `date_time_render_option`
  - changed `note` to `warning`
  - explained that if `value_render_option` is set to `ValueRenderOption.formatted`, a `gspread.exceptions.APIError` will be raised