### PR TITLE
Fix rows_auto_resize in worksheet.py by removing redundant self

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1521,7 +1521,7 @@ class Worksheet:
 
         .. versionadded:: 5.3.3
         """
-        return self._auto_resize(self, start_row_index, end_row_index, Dimension.rows)
+        return self._auto_resize(start_row_index, end_row_index, Dimension.rows)
 
     def add_rows(self, rows):
         """Adds rows to worksheet.


### PR DESCRIPTION
Solves the issue https://github.com/burnash/gspread/issues/1193

Closes #1193