### PR TITLE
#966  Add sketch typing for utils.py

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -158,7 +158,7 @@ def finditem(func: Callable[[T], bool], seq: Iterable[T]) -> T:
 def numericise(
     value: Optional[AnyStr],
     empty2zero: bool = False,
-    default_blank: Optional[str] = "",
+    default_blank: Optional[AnyStr] = "",
     allow_underscores_in_numeric_literals: bool = False,
 ) -> Optional[Union[int, float, AnyStr]]:
     """Returns a value that depends on the input:
@@ -233,7 +233,7 @@ def numericise(
 def numericise_all(
     values: List[Optional[AnyStr]],
     empty2zero: bool = False,
-    default_blank: Union[AnyStr, int, float] = "",
+    default_blank: Optional[AnyStr] = "",
     allow_underscores_in_numeric_literals: bool = False,
     ignore: List[int] = [],
 ) -> List[Optional[Union[int, float, AnyStr]]]:

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -581,7 +581,7 @@ def fill_gaps(
         return [[]]
 
 
-def cell_list_to_rect(cell_list: List["Cell"]) -> List[List[Optional[str]]]:
+def cell_list_to_rect(cell_list: List[Any]) -> List[List[Optional[str]]]:
     if not cell_list:
         return []
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from functools import wraps
 from itertools import chain
 from typing import (
+    TYPE_CHECKING,
     Any,
     AnyStr,
     Callable,
@@ -31,6 +32,10 @@ from google.oauth2.credentials import Credentials as UserCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 
 from .exceptions import IncorrectCellLabel, InvalidInputValue, NoValidUrlKeyFound
+
+if TYPE_CHECKING:
+    from .cell import Cell
+
 
 MAGIC_NUMBER = 64
 CELL_ADDR_RE = re.compile(r"([A-Za-z]+)([1-9]\d*)")
@@ -569,7 +574,7 @@ def fill_gaps(
         return [[]]
 
 
-def cell_list_to_rect(cell_list: List[Any]) -> List[List[Optional[str]]]:
+def cell_list_to_rect(cell_list: List["Cell"]) -> List[List[Optional[str]]]:
     if not cell_list:
         return []
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -11,17 +11,27 @@ from collections import defaultdict, namedtuple
 from collections.abc import Sequence
 from functools import wraps
 from itertools import chain
-from typing import (Any, AnyStr, Callable, Dict, Iterable, List, NewType,
-                    Optional, Tuple, TypedDict, TypeVar, Union)
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NewType,
+    Optional,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 from urllib.parse import quote as uquote
 
 from google.auth.credentials import Credentials as Credentials
 from google.oauth2.credentials import Credentials as UserCredentials
-from google.oauth2.service_account import \
-    Credentials as ServiceAccountCredentials
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 
-from .exceptions import (IncorrectCellLabel, InvalidInputValue,
-                         NoValidUrlKeyFound)
+from .exceptions import IncorrectCellLabel, InvalidInputValue, NoValidUrlKeyFound
 
 MAGIC_NUMBER = 64
 CELL_ADDR_RE = re.compile(r"([A-Za-z]+)([1-9]\d*)")
@@ -54,8 +64,7 @@ MimeType = MimeTypeType(
     "application/zip",
 )
 ExportFormatType = namedtuple(
-    "ExportFormat", ["PDF", "EXCEL", "CSV",
-                     "OPEN_OFFICE_SHEET", "TSV", "ZIPPED_HTML"]
+    "ExportFormat", ["PDF", "EXCEL", "CSV", "OPEN_OFFICE_SHEET", "TSV", "ZIPPED_HTML"]
 )
 ExportFormat = ExportFormatType(
     MimeType.pdf,
@@ -396,10 +405,7 @@ GridRange = TypedDict(
 )
 
 
-def a1_range_to_grid_range(
-    name: str,
-    sheet_id: Optional[int] = None
-) -> GridRange:
+def a1_range_to_grid_range(name: str, sheet_id: Optional[int] = None) -> GridRange:
     """Converts a range defined in A1 notation to a dict representing
     a `GridRange`_.
 
@@ -440,8 +446,7 @@ def a1_range_to_grid_range(
 
     start_row_index, start_column_index = _a1_to_rowcol_unbounded(start_label)
 
-    end_row_index, end_column_index = _a1_to_rowcol_unbounded(
-        end_label or start_label)
+    end_row_index, end_column_index = _a1_to_rowcol_unbounded(end_label or start_label)
 
     if start_row_index > end_row_index:
         start_row_index, end_row_index = end_row_index, start_row_index
@@ -457,9 +462,7 @@ def a1_range_to_grid_range(
     }
 
     filtered_grid_range: Dict[str, int] = {
-        key: value
-        for (key, value) in grid_range.items()
-        if isinstance(value, int)
+        key: value for (key, value) in grid_range.items() if isinstance(value, int)
     }
 
     if sheet_id is not None:
@@ -562,9 +565,7 @@ def rightpad(row: List[Any], max_len: int) -> List[Any]:
 
 
 def fill_gaps(
-    L: List[List[Any]],
-    rows: Optional[int] = None,
-    cols: Optional[int] = None
+    L: List[List[Any]], rows: Optional[int] = None, cols: Optional[int] = None
 ) -> List[List[Any]]:
     try:
         max_cols = max(len(row) for row in L) if cols is None else cols
@@ -611,10 +612,7 @@ def quote(value: str, safe: str = "", encoding: str = "utf-8") -> str:
     return uquote(value.encode(encoding), safe)
 
 
-def absolute_range_name(
-    sheet_name: str,
-    range_name: Optional[str] = None
-) -> str:
+def absolute_range_name(sheet_name: str, range_name: Optional[str] = None) -> str:
     """Return an absolutized path of a range.
 
     >>> absolute_range_name("Sheet1", "A1:B1")
@@ -691,7 +689,7 @@ def filter_dict_values(D: Dict[Any, Any]) -> Dict[Any, AnyNotNone]:
 
 
 def accepted_kwargs(
-    **default_kwargs: Any
+    **default_kwargs: Any,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     >>> @accepted_kwargs(d='d', e=None)

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -220,7 +220,7 @@ def numericise(
 def numericise_all(
     values: List[Optional[AnyStr]],
     empty2zero: bool = False,
-    default_blank: Optional[str] = "",
+    default_blank: Union[AnyStr, int, float] = "",
     allow_underscores_in_numeric_literals: bool = False,
     ignore: List[int] = [],
 ) -> List[Optional[Union[int, float, AnyStr]]]:
@@ -562,10 +562,10 @@ def rightpad(row: List[Any], max_len: int) -> List[Any]:
 
 
 def fill_gaps(
-    L: List[Any],
+    L: List[List[Any]],
     rows: Optional[int] = None,
     cols: Optional[int] = None
-) -> List[Any]:
+) -> List[List[Any]]:
     try:
         max_cols = max(len(row) for row in L) if cols is None else cols
         max_rows = len(L) if rows is None else rows
@@ -577,7 +577,7 @@ def fill_gaps(
 
         return [rightpad(row, max_cols) for row in L]
     except ValueError:
-        return []
+        return [[]]
 
 
 def cell_list_to_rect(cell_list: List["Cell"]) -> List[List[Optional[str]]]:

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -21,7 +21,6 @@ from typing import (
     NewType,
     Optional,
     Tuple,
-    TypedDict,
     TypeVar,
     Union,
 )
@@ -394,18 +393,7 @@ def _a1_to_rowcol_unbounded(label: str) -> Tuple[IntOrInf, IntOrInf]:
     return (row, col)
 
 
-GridRange = TypedDict(
-    "GridRange",
-    {
-        "startRowIndex": Optional[int],
-        "endRowIndex": Optional[int],
-        "startColumnIndex": Optional[int],
-        "endColumnIndex": Optional[int],
-    },
-)
-
-
-def a1_range_to_grid_range(name: str, sheet_id: Optional[int] = None) -> GridRange:
+def a1_range_to_grid_range(name: str, sheet_id: Optional[int] = None) -> Dict[str, int]:
     """Converts a range defined in A1 notation to a dict representing
     a `GridRange`_.
 
@@ -468,7 +456,7 @@ def a1_range_to_grid_range(name: str, sheet_id: Optional[int] = None) -> GridRan
     if sheet_id is not None:
         filtered_grid_range["sheetId"] = sheet_id
 
-    return GridRange(**filtered_grid_range)
+    return filtered_grid_range
 
 
 def column_letter_to_index(column: str) -> int:

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -788,7 +788,7 @@ class WorksheetTest(GspreadTest):
         self.sheet.update_cells(cell_list)
 
         self.sheet.clear()
-        self.assertEqual(self.sheet.get_all_values(), [])
+        self.assertEqual(self.sheet.get_all_values(), [[]])
 
     @pytest.mark.vcr()
     def test_update_and_get(self):
@@ -934,24 +934,24 @@ class WorksheetTest(GspreadTest):
         w = self.spreadsheet.sheet1
 
         # make sure cells are empty
-        self.assertListEqual(w.get_values("A1:B1"), [])
-        self.assertListEqual(w.get_values("C2:E2"), [])
+        self.assertListEqual(w.get_values("A1:B1"), [[]])
+        self.assertListEqual(w.get_values("C2:E2"), [[]])
 
         # fill the cells
         w.update("A1:B1", [["12345", "ThisIsText"]])
         w.update("C2:E2", [["5678", "Second", "Text"]])
 
         # confirm the cells are not empty
-        self.assertNotEqual(w.get_values("A1:B1"), [])
-        self.assertNotEqual(w.get_values("C2:E2"), [])
+        self.assertNotEqual(w.get_values("A1:B1"), [[]])
+        self.assertNotEqual(w.get_values("C2:E2"), [[]])
 
         # empty both cell range at once
         w.batch_clear(["A1:B1", "C2:E2"])
 
         # confirm cells are empty
         # make sure cells are empty
-        self.assertListEqual(w.get_values("A1:B1"), [])
-        self.assertListEqual(w.get_values("C2:E2"), [])
+        self.assertListEqual(w.get_values("A1:B1"), [[]])
+        self.assertListEqual(w.get_values("C2:E2"), [[]])
 
     @pytest.mark.vcr()
     def test_group_columns(self):


### PR DESCRIPTION
I add sketch types for `utils.py` but have following issues:

### Optional  imports

OAuth2Credentials, AccessTokenCredentials, GoogleCredentials, ServiceAccountCredentials are optional and only needed for oauth2client, so cannot be resolved as a type.

Currently, I have to use the following code to make it work:

```python
def _convert_oauth(credentials: Any) -> Credentials:
    ...

def _convert_service_account(credentials: Any) -> Credentials:
    ...
```

But it's not ideal, because it's not type safe. I think, we can add try-except imports to functions body:

```python
def _convert_oauth(credentials: Any) -> Credentials:
    try:
        from oauth2client.client import OAuth2Credentials, AccessTokenCredentials, GoogleCredentials
    except ImportError:
        pass
    ...
```

### NamedTuples used as enums

NamedTuples are used for options, but it's not proper way to use them. It also produce type checking issues.

I think, we can use Enum instead of NamedTuple, if there is no reasons for backward compatibility.

### Some unclear types

I'm not sure if I have set the correct types for some functions because they are not explained anywhere. Therefore, I need some validation of my propositions.
