### PR TITLE
CLEANUP: cleanup tox.ini, and ignore ./env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ statistics = True
 
 [isort]
 skip=.tox,./env
+profile=black
 
 # Used by the CI to check code format/security
 [testenv:lint]
@@ -30,14 +31,14 @@ deps = -r lint-requirements.txt
 commands = black --check --diff .
         codespell --skip=".tox,.git,./docs/build,./env" .
         flake8 .
-        isort --check-only --profile black .
+        isort --check-only .
 
 # Used by developers to format code, best advised to be run before commit
 [testenv:format]
 description = Format code
 deps = -r lint-requirements.txt
 commands = black .
-        isort --profile black .
+        isort .
 
 
 [testenv:build]

--- a/tox.ini
+++ b/tox.ini
@@ -14,14 +14,14 @@ commands = pytest {posargs} tests/
 
 [flake8]
 extend-ignore = E203
-exclude = .tox,./env
+extend-exclude = .tox,./env
 max-line-length = 255
 max-complexity = 10
 show-source = True
 statistics = True
 
 [isort]
-skip=.tox,./env
+extend_skip=.tox,./env
 profile=black
 
 # Used by the CI to check code format/security

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ profile=black
 [testenv:lint]
 description = Run code linters
 deps = -r lint-requirements.txt
-commands = black --check --diff .
+commands = black --check --diff --extend-exclude "/env" .
         codespell --skip=".tox,.git,./docs/build,./env" .
         flake8 .
         isort --check-only .
@@ -37,7 +37,7 @@ commands = black --check --diff .
 [testenv:format]
 description = Format code
 deps = -r lint-requirements.txt
-commands = black .
+commands = black --extend-exclude "/env" .
         isort .
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands = pytest {posargs} tests/
 
 [flake8]
 extend-ignore = E203
-exclude = .tox
+exclude = .tox,./env
 max-line-length = 255
 max-complexity = 10
 show-source = True
@@ -25,7 +25,7 @@ statistics = True
 description = Run code linters
 deps = -r lint-requirements.txt
 commands = black --check --diff .
-        codespell --skip=".tox,.git,./docs/build" .
+        codespell --skip=".tox,.git,./docs/build,./env" .
         flake8 .
         isort --check-only --profile black .
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,9 @@ max-complexity = 10
 show-source = True
 statistics = True
 
+[isort]
+skip=.tox,./env
+
 # Used by the CI to check code format/security
 [testenv:lint]
 description = Run code linters

--- a/tox.ini
+++ b/tox.ini
@@ -12,14 +12,21 @@ passenv =
 deps = -r test-requirements.txt
 commands = pytest {posargs} tests/
 
+[flake8]
+extend-ignore = E203
+exclude = .tox
+max-line-length = 255
+max-complexity = 10
+show-source = True
+statistics = True
+
 # Used by the CI to check code format/security
 [testenv:lint]
 description = Run code linters
 deps = -r lint-requirements.txt
 commands = black --check --diff .
         codespell --skip=".tox,.git,./docs/build" .
-        flake8 --ignore=E203 --max-complexity=10 --max-line-length=255 \
-            --show-source --statistics .
+        flake8 .
         isort --check-only --profile black .
 
 # Used by developers to format code, best advised to be run before commit

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ profile=black
 [testenv:lint]
 description = Run code linters
 deps = -r lint-requirements.txt
-commands = black --check --diff --extend-exclude "/env" .
+commands = black --check --diff --extend-exclude "./env" .
         codespell --skip=".tox,.git,./docs/build,./env" .
         flake8 .
         isort --check-only .
@@ -37,7 +37,7 @@ commands = black --check --diff --extend-exclude "/env" .
 [testenv:format]
 description = Format code
 deps = -r lint-requirements.txt
-commands = black --extend-exclude "/env" .
+commands = black --extend-exclude "./env" .
         isort .
 
 


### PR DESCRIPTION
tox was taking a long time to run.  This was because it was checking all the files in my python virtual environment, in `./env`.

The [.gitignore](https://github.com/burnash/gspread/blob/master/.gitignore#L9) suggests that a python virtual environment should be called `env`, which is what mine is.

I have added a skip/ignore to the lint/format commands, so they no longer look in `./env`. 

This also has the benefit that they are much faster to run (around 8 secs to lint, 5 secs to format).