### PR TITLE
add legacy option for DateTimeOption

### DIFF
--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -35,8 +35,8 @@ ValueRenderOption = namedtuple(
 ValueInputOption = namedtuple("ValueInputOption", ["raw", "user_entered"])(
     "RAW", "USER_ENTERED"
 )
-DateTimeOption = namedtuple("DateTimeOption", ["serial_number", "formatted_string"])(
-    "SERIAL_NUMBER", "FORMATTED_STRING"
+DateTimeOption = namedtuple("DateTimeOption", ["serial_number", "formatted_string", "formated_string"])(
+    "SERIAL_NUMBER", "FORMATTED_STRING", "FORMATTED_STRING"
 )
 MimeTypeType = namedtuple(
     "MimeType",

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -35,9 +35,9 @@ ValueRenderOption = namedtuple(
 ValueInputOption = namedtuple("ValueInputOption", ["raw", "user_entered"])(
     "RAW", "USER_ENTERED"
 )
-DateTimeOption = namedtuple("DateTimeOption", ["serial_number", "formatted_string", "formated_string"])(
-    "SERIAL_NUMBER", "FORMATTED_STRING", "FORMATTED_STRING"
-)
+DateTimeOption = namedtuple(
+    "DateTimeOption", ["serial_number", "formatted_string", "formated_string"]
+)("SERIAL_NUMBER", "FORMATTED_STRING", "FORMATTED_STRING")
 MimeTypeType = namedtuple(
     "MimeType",
     ["google_sheets", "pdf", "excel", "csv", "open_office_sheet", "tsv", "zip"],


### PR DESCRIPTION
now, someone can use the correct (new) spelling, or the incorrect (old) spelling
this is thus not longer a breaking change

See #1187 for further discussion