### PR TITLE
remove deprecated methods from tests

### DIFF
--- a/tests/spreadsheet_test.py
+++ b/tests/spreadsheet_test.py
@@ -192,17 +192,15 @@ class SpreadsheetTest(GspreadTest):
 
     @pytest.mark.vcr()
     def test_get_updated_time(self):
-        current_metadata = self.spreadsheet._properties
-        self.assertNotIn("modifiedTime", self.spreadsheet._properties)
+        metadata_before = self.spreadsheet._properties
+        self.assertNotIn("modifiedTime", metadata_before)
 
-        res = self.spreadsheet.lastUpdateTime
+        lastUpdateTime = self.spreadsheet.lastUpdateTime
+        metadata_after = self.spreadsheet._properties
 
-        self.assertIsNotNone(res)
-
-        new_metadata = self.spreadsheet._properties
-        self.assertIn("modifiedTime", self.spreadsheet._properties)
-
-        self.assertDictContainsSubset(current_metadata, new_metadata)
+        self.assertIsNotNone(lastUpdateTime)
+        self.assertIn("modifiedTime", metadata_after)
+        self.assertEqual(lastUpdateTime, metadata_after["modifiedTime"])
 
     @pytest.mark.vcr()
     def test_refresh_lastUpdateTime(self):

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -994,17 +994,17 @@ class WorksheetTest(GspreadTest):
 
     @pytest.mark.vcr()
     def test_delete_row(self):
-        sg = self._sequence_generator()
+        sequence_generator = self._sequence_generator()
 
         for i in range(5):
-            value_list = [next(sg) for i in range(10)]
+            value_list = [next(sequence_generator) for i in range(10)]
             self.sheet.append_row(value_list)
 
         prev_row = self.sheet.row_values(1)
         next_row = self.sheet.row_values(3)
         row_count_before = self.sheet.row_count
 
-        self.sheet.delete_row(2)
+        self.sheet.delete_rows(2)
 
         row_count_after = self.sheet.row_count
         self.assertEqual(row_count_before - 1, row_count_after)


### PR DESCRIPTION
test output has a lot of space.

this removes some warnings for deprecated methods

there are still some warnings for future deprecated methods which should disappear in 6.0.0