### PR TITLE
Remplace named tuples with enums

### DIFF
--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,15 +1,6 @@
 Utils
 =====
 
-.. autonamedtuple:: gspread.utils.Dimension
-.. autonamedtuple:: gspread.utils.DateTimeOption
-.. autonamedtuple:: gspread.utils.ExportFormat
-.. autonamedtuple:: gspread.utils.MimeType
-.. autonamedtuple:: gspread.utils.PasteOrientation
-.. autonamedtuple:: gspread.utils.PasteType
-.. autonamedtuple:: gspread.utils.ValueInputOption
-.. autonamedtuple:: gspread.utils.ValueRenderOption
-
 .. automodule:: gspread.utils
    :members:
    :undoc-members:

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -56,7 +56,7 @@ class Client:
         page_token = ""
         url = DRIVE_FILES_API_V3_URL
 
-        q = 'mimeType="{}"'.format(MimeType.google_sheets)
+        q = 'mimeType="{}"'.format(MimeType.google_sheets.value)
         if title:
             q += ' and name = "{}"'.format(title)
         if folder_id:
@@ -166,7 +166,7 @@ class Client:
         """
         payload = {
             "name": title,
-            "mimeType": MimeType.google_sheets,
+            "mimeType": MimeType.google_sheets.value,
         }
 
         params: ParamsType = {
@@ -199,7 +199,7 @@ class Client:
 
             See `ExportFormat`_ in the Drive API.
 
-        :type format: :namedtuple:`~gspread.utils.ExportFormat`
+        :type format: :class:`~gspread.utils.ExportFormat`
 
         :returns bytes: The content of the exported file.
 
@@ -211,7 +211,7 @@ class Client:
 
         url = "{}/{}/export".format(DRIVE_FILES_API_V3_URL, file_id)
 
-        params: ParamsType = {"mimeType": format}
+        params: ParamsType = {"mimeType": format.value}
 
         r = self.http_client.request("get", url, params=params)
         return r.content
@@ -263,7 +263,7 @@ class Client:
 
         payload = {
             "name": title,
-            "mimeType": MimeType.google_sheets,
+            "mimeType": MimeType.google_sheets.value,
         }
 
         if folder_id is not None:

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -56,7 +56,7 @@ class Client:
         page_token = ""
         url = DRIVE_FILES_API_V3_URL
 
-        q = 'mimeType="{}"'.format(MimeType.google_sheets.value)
+        q = 'mimeType="{}"'.format(MimeType.google_sheets)
         if title:
             q += ' and name = "{}"'.format(title)
         if folder_id:
@@ -166,7 +166,7 @@ class Client:
         """
         payload = {
             "name": title,
-            "mimeType": MimeType.google_sheets.value,
+            "mimeType": MimeType.google_sheets,
         }
 
         params: ParamsType = {
@@ -211,7 +211,7 @@ class Client:
 
         url = "{}/{}/export".format(DRIVE_FILES_API_V3_URL, file_id)
 
-        params: ParamsType = {"mimeType": format.value}
+        params: ParamsType = {"mimeType": format}
 
         r = self.http_client.request("get", url, params=params)
         return r.content
@@ -263,7 +263,7 @@ class Client:
 
         payload = {
             "name": title,
-            "mimeType": MimeType.google_sheets.value,
+            "mimeType": MimeType.google_sheets,
         }
 
         if folder_id is not None:

--- a/gspread/spreadsheet.py
+++ b/gspread/spreadsheet.py
@@ -496,7 +496,7 @@ class Spreadsheet:
 
             See `ExportFormat`_ in the Drive API.
             Default value is ``ExportFormat.PDF``.
-        :type format: :namedtuple:`~gspread.utils.ExportFormat`
+        :type format: :class:`~gspread.utils.ExportFormat`
 
         :returns bytes: The content of the exported file.
 

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -9,7 +9,6 @@ This module contains utility functions.
 import re
 from collections import defaultdict
 from collections.abc import Sequence
-from enum import Enum
 from functools import wraps
 from itertools import chain
 from typing import (
@@ -20,7 +19,6 @@ from typing import (
     Dict,
     Iterable,
     List,
-    MutableMapping,
     Optional,
     Tuple,
     TypeVar,
@@ -31,6 +29,7 @@ from urllib.parse import quote as uquote
 from google.auth.credentials import Credentials as Credentials
 from google.oauth2.credentials import Credentials as UserCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
+from strenum import StrEnum
 
 from .exceptions import IncorrectCellLabel, InvalidInputValue, NoValidUrlKeyFound
 
@@ -46,28 +45,28 @@ URL_KEY_V1_RE = re.compile(r"key=([^&#]+)")
 URL_KEY_V2_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9-_]+)")
 
 
-class Dimension(Enum):
+class Dimension(StrEnum):
     rows = "ROWS"
     cols = "COLUMNS"
 
 
-class ValueRenderOption(Enum):
+class ValueRenderOption(StrEnum):
     formatted = "FORMATTED_VALUE"
     unformatted = "UNFORMATTED_VALUE"
     formula = "FORMULA"
 
 
-class ValueInputOption(Enum):
+class ValueInputOption(StrEnum):
     raw = "RAW"
     user_entered = "USER_ENTERED"
 
 
-class DateTimeOption(Enum):
+class DateTimeOption(StrEnum):
     serial_number = "SERIAL_NUMBER"
     formatted_string = "FORMATTED_STRING"
 
 
-class MimeType(Enum):
+class MimeType(StrEnum):
     google_sheets = "application/vnd.google-apps.spreadsheet"
     pdf = "application/pdf"
     excel = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -77,16 +76,16 @@ class MimeType(Enum):
     zip = "application/zip"
 
 
-class ExportFormat(Enum):
-    PDF = MimeType.pdf.value
-    EXCEL = MimeType.excel.value
-    CSV = MimeType.csv.value
-    OPEN_OFFICE_SHEET = MimeType.open_office_sheet.value
-    TSV = MimeType.tsv.value
-    ZIPPED_HTML = MimeType.zip.value
+class ExportFormat(StrEnum):
+    PDF = MimeType.pdf
+    EXCEL = MimeType.excel
+    CSV = MimeType.csv
+    OPEN_OFFICE_SHEET = MimeType.open_office_sheet
+    TSV = MimeType.tsv
+    ZIPPED_HTML = MimeType.zip
 
 
-class PasteType(Enum):
+class PasteType(StrEnum):
     normal = "PASTE_NORMAL"
     values = "PASTE_VALUES"
     format = "PASTE_FORMAT"
@@ -96,7 +95,7 @@ class PasteType(Enum):
     conditional_formating = "PASTE_CONDITIONAL_FORMATTING"
 
 
-class PasteOrientation(Enum):
+class PasteOrientation(StrEnum):
     normal = "NORMAL"
     transpose = "TRANSPOSE"
 
@@ -144,12 +143,6 @@ def _convert_service_account(credentials: Any) -> Credentials:
 
 
 T = TypeVar("T")
-
-
-def extract_enum_values(
-    params: MutableMapping[str, Union[None, Enum]]
-) -> Dict[str, str]:
-    return {k: v.value for k, v in params.items() if v is not None}
 
 
 def finditem(func: Callable[[T], bool], seq: Iterable[T]) -> T:

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -7,8 +7,9 @@ This module contains utility functions.
 """
 
 import re
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from collections.abc import Sequence
+from enum import Enum
 from functools import wraps
 from itertools import chain
 from typing import (
@@ -19,6 +20,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    MutableMapping,
     Optional,
     Tuple,
     TypeVar,
@@ -43,69 +45,60 @@ A1_ADDR_ROW_COL_RE = re.compile(r"([A-Za-z]+)?([1-9]\d*)?$")
 URL_KEY_V1_RE = re.compile(r"key=([^&#]+)")
 URL_KEY_V2_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9-_]+)")
 
-Dimension = namedtuple("Dimension", ["rows", "cols"])("ROWS", "COLUMNS")
-ValueRenderOption = namedtuple(
-    "ValueRenderOption", ["formatted", "unformatted", "formula"]
-)("FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA")
-ValueInputOption = namedtuple("ValueInputOption", ["raw", "user_entered"])(
-    "RAW", "USER_ENTERED"
-)
-DateTimeOption = namedtuple(
-    "DateTimeOption", ["serial_number", "formatted_string", "formated_string"]
-)("SERIAL_NUMBER", "FORMATTED_STRING", "FORMATTED_STRING")
-MimeTypeType = namedtuple(
-    "MimeType",
-    ["google_sheets", "pdf", "excel", "csv", "open_office_sheet", "tsv", "zip"],
-)
-MimeType = MimeTypeType(
-    "application/vnd.google-apps.spreadsheet",
-    "application/pdf",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "text/csv",
-    "application/vnd.oasis.opendocument.spreadsheet",
-    "text/tab-separated-values",
-    "application/zip",
-)
-ExportFormatType = namedtuple(
-    "ExportFormat", ["PDF", "EXCEL", "CSV", "OPEN_OFFICE_SHEET", "TSV", "ZIPPED_HTML"]
-)
-ExportFormat = ExportFormatType(
-    MimeType.pdf,
-    MimeType.excel,
-    MimeType.csv,
-    MimeType.open_office_sheet,
-    MimeType.tsv,
-    MimeType.zip,
-)
 
-PasteType = namedtuple(
-    "PasteType",
-    [
-        "normal",
-        "values",
-        "format",
-        "no_borders",
-        "formula",
-        "data_validation",
-        "conditional_formating",
-    ],
-)(
-    "PASTE_NORMAL",
-    "PASTE_VALUES",
-    "PASTE_FORMAT",
-    "PASTE_NO_BORDERS",
-    "PASTE_FORMULA",
-    "PASTE_DATA_VALIDATION",
-    "PASTE_CONDITIONAL_FORMATTING",
-)
+class Dimension(Enum):
+    rows = "ROWS"
+    cols = "COLUMNS"
 
-PasteOrientation = namedtuple("PasteOrientation", ["normal", "transpose"])(
-    "NORMAL", "TRANSPOSE"
-)
 
-DEPRECATION_WARNING_TEMPLATE = (
-    "[Deprecated][in version {v_deprecated}]: {msg_deprecated}"
-)
+class ValueRenderOption(Enum):
+    formatted = "FORMATTED_VALUE"
+    unformatted = "UNFORMATTED_VALUE"
+    formula = "FORMULA"
+
+
+class ValueInputOption(Enum):
+    raw = "RAW"
+    user_entered = "USER_ENTERED"
+
+
+class DateTimeOption(Enum):
+    serial_number = "SERIAL_NUMBER"
+    formatted_string = "FORMATTED_STRING"
+
+
+class MimeType(Enum):
+    google_sheets = "application/vnd.google-apps.spreadsheet"
+    pdf = "application/pdf"
+    excel = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    csv = "text/csv"
+    open_office_sheet = "application/vnd.oasis.opendocument.spreadsheet"
+    tsv = "text/tab-separated-values"
+    zip = "application/zip"
+
+
+class ExportFormat(Enum):
+    PDF = MimeType.pdf.value
+    EXCEL = MimeType.excel.value
+    CSV = MimeType.csv.value
+    OPEN_OFFICE_SHEET = MimeType.open_office_sheet.value
+    TSV = MimeType.tsv.value
+    ZIPPED_HTML = MimeType.zip.value
+
+
+class PasteType(Enum):
+    normal = "PASTE_NORMAL"
+    values = "PASTE_VALUES"
+    format = "PASTE_FORMAT"
+    no_borders = "PASTE_NO_BORDERS"
+    formula = "PASTE_NO_BORDERS"
+    data_validation = "PASTE_DATA_VALIDATION"
+    conditional_formating = "PASTE_CONDITIONAL_FORMATTING"
+
+
+class PasteOrientation(Enum):
+    normal = "NORMAL"
+    transpose = "TRANSPOSE"
 
 
 def convert_credentials(credentials: Credentials) -> Credentials:
@@ -151,6 +144,12 @@ def _convert_service_account(credentials: Any) -> Credentials:
 
 
 T = TypeVar("T")
+
+
+def extract_enum_values(
+    params: MutableMapping[str, Union[None, Enum]]
+) -> Dict[str, str]:
+    return {k: v.value for k, v in params.items() if v is not None}
 
 
 def finditem(func: Callable[[T], bool], seq: Iterable[T]) -> T:

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -21,7 +21,6 @@ from .utils import (
     cast_to_a1_notation,
     cell_list_to_rect,
     combined_merge_values,
-    extract_enum_values,
     fill_gaps,
     finditem,
     is_scalar,
@@ -669,8 +668,8 @@ class Worksheet:
             self.spreadsheet_id,
             range_name,
             params={
-                "valueRenderOption": value_render_option.value,
-                "majorDimension": Dimension.cols.value,
+                "valueRenderOption": value_render_option,
+                "majorDimension": Dimension.cols,
             },
         )
 
@@ -707,7 +706,7 @@ class Worksheet:
         data = self.client.values_update(
             self.spreadsheet_id,
             range_name,
-            params={"valueInputOption": ValueInputOption.user_entered.value},
+            params={"valueInputOption": ValueInputOption.user_entered},
             body={"values": [[value]]},
         )
 
@@ -760,7 +759,7 @@ class Worksheet:
         data = self.client.values_update(
             self.spreadsheet_id,
             range_name,
-            params={"valueInputOption": value_input_option.value},
+            params={"valueInputOption": value_input_option},
             body={"values": values_rect},
         )
 
@@ -850,13 +849,11 @@ class Worksheet:
         """
         range_name = absolute_range_name(self.title, range_name)
 
-        params = extract_enum_values(
-            {
-                "majorDimension": major_dimension,
-                "valueRenderOption": value_render_option,
-                "dateTimeRenderOption": date_time_render_option,
-            }
-        )
+        params = {
+            "majorDimension": major_dimension,
+            "valueRenderOption": value_render_option,
+            "dateTimeRenderOption": date_time_render_option,
+        }
 
         response = self.client.values_get(
             self.spreadsheet_id, range_name, params=params
@@ -937,13 +934,11 @@ class Worksheet:
         """
         ranges = [absolute_range_name(self.title, r) for r in ranges if r]
 
-        params = extract_enum_values(
-            {
-                "majorDimension": major_dimension,
-                "valueRenderOption": value_render_option,
-                "dateTimeRenderOption": date_time_render_option,
-            }
-        )
+        params = {
+            "majorDimension": major_dimension,
+            "valueRenderOption": value_render_option,
+            "dateTimeRenderOption": date_time_render_option,
+        }
 
         response = self.client.values_batch_get(
             self.spreadsheet_id, ranges=ranges, params=params
@@ -1079,25 +1074,18 @@ class Worksheet:
                 ValueInputOption.raw if raw is True else ValueInputOption.user_entered
             )
 
-        params = extract_enum_values(
-            {
-                "valueInputOption": value_input_option,
-                "includeValuesInResponse": include_values_in_response,
-                "responseValueRenderOption": response_value_render_option,
-                "responseDateTimeRenderOption": response_date_time_render_option,
-            }
-        )
-
-        # get actual value only if not None
-        major_dimension_value = (
-            major_dimension.value if major_dimension is not None else None
-        )
+        params = {
+            "valueInputOption": value_input_option,
+            "includeValuesInResponse": include_values_in_response,
+            "responseValueRenderOption": response_value_render_option,
+            "responseDateTimeRenderOption": response_date_time_render_option,
+        }
 
         response = self.client.values_update(
             self.spreadsheet_id,
             range_name,
             params=params,
-            body={"values": values, "majorDimension": major_dimension_value},
+            body={"values": values, "majorDimension": major_dimension},
         )
 
         return response
@@ -1208,13 +1196,11 @@ class Worksheet:
             dict(vr, range=absolute_range_name(self.title, vr["range"])) for vr in data
         ]
 
-        body = extract_enum_values(
-            {
-                "valueInputOption": value_input_option,
-                "responseValueRenderOption": response_value_render_option,
-                "responseDateTimeRenderOption": response_date_time_render_option,
-            }
-        )
+        body = {
+            "valueInputOption": value_input_option,
+            "responseValueRenderOption": response_value_render_option,
+            "responseDateTimeRenderOption": response_date_time_render_option,
+        }
 
         body["includeValuesInResponse"] = include_values_in_response
         body["data"] = data
@@ -1577,7 +1563,7 @@ class Worksheet:
                     "autoResizeDimensions": {
                         "dimensions": {
                             "sheetId": self.id,
-                            "dimension": dimension.value,
+                            "dimension": dimension,
                             "startIndex": int(start_index),
                             "endIndex": int(end_index),
                         }
@@ -1706,12 +1692,10 @@ class Worksheet:
         """
         range_label = absolute_range_name(self.title, table_range)
 
-        params = extract_enum_values(
-            {
-                "valueInputOption": value_input_option,
-                "insertDataOption": insert_data_option,
-            }
-        )
+        params = {
+            "valueInputOption": value_input_option,
+            "insertDataOption": insert_data_option,
+        }
 
         # Not an Enum, does not pass `extract_enum_values`
         params["includeValuesInResponse"] = include_values_in_response
@@ -1811,7 +1795,7 @@ class Worksheet:
                     "insertDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": Dimension.rows.value,
+                            "dimension": Dimension.rows,
                             "startIndex": row - 1,
                             "endIndex": len(values) + row - 1,
                         },
@@ -1825,9 +1809,9 @@ class Worksheet:
 
         range_label = absolute_range_name(self.title, "A%s" % row)
 
-        params = {"valueInputOption": value_input_option.value}
+        params = {"valueInputOption": value_input_option}
 
-        body = {"majorDimension": Dimension.rows.value, "values": values}
+        body = {"majorDimension": Dimension.rows, "values": values}
 
         res = self.client.values_append(self.spreadsheet_id, range_label, params, body)
         num_new_rows = len(values)
@@ -1876,7 +1860,7 @@ class Worksheet:
                     "insertDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": Dimension.cols.value,
+                            "dimension": Dimension.cols,
                             "startIndex": col - 1,
                             "endIndex": len(values) + col - 1,
                         },
@@ -1890,9 +1874,9 @@ class Worksheet:
 
         range_label = absolute_range_name(self.title, rowcol_to_a1(1, col))
 
-        params = {"valueInputOption": value_input_option.value}
+        params = {"valueInputOption": value_input_option}
 
-        body = {"majorDimension": Dimension.cols.value, "values": values}
+        body = {"majorDimension": Dimension.cols, "values": values}
 
         res = self.client.values_append(self.spreadsheet_id, range_label, params, body)
         num_new_cols = len(values)
@@ -2007,7 +1991,7 @@ class Worksheet:
                     "deleteDimension": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": dimension.value,
+                            "dimension": dimension,
                             "startIndex": start_index - 1,
                             "endIndex": end_index,
                         }
@@ -2636,7 +2620,7 @@ class Worksheet:
                     "addDimensionGroup": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": dimension.value,
+                            "dimension": dimension,
                             "startIndex": start,
                             "endIndex": end,
                         },
@@ -2685,7 +2669,7 @@ class Worksheet:
                     "deleteDimensionGroup": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": dimension.value,
+                            "dimension": dimension,
                             "startIndex": start,
                             "endIndex": end,
                         }
@@ -2761,7 +2745,7 @@ class Worksheet:
                     "updateDimensionProperties": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": dimension.value,
+                            "dimension": dimension,
                             "startIndex": start,
                             "endIndex": end,
                         },
@@ -2816,7 +2800,7 @@ class Worksheet:
                     "updateDimensionProperties": {
                         "range": {
                             "sheetId": self.id,
-                            "dimension": dimension.value,
+                            "dimension": dimension,
                             "startIndex": start,
                             "endIndex": end,
                         },
@@ -2949,8 +2933,8 @@ class Worksheet:
                     "copyPaste": {
                         "source": a1_range_to_grid_range(source, self.id),
                         "destination": a1_range_to_grid_range(dest, self.id),
-                        "pasteType": paste_type.value,
-                        "pasteOrientation": paste_orientation.value,
+                        "pasteType": paste_type,
+                        "pasteOrientation": paste_orientation,
                     }
                 }
             ]
@@ -2996,7 +2980,7 @@ class Worksheet:
                             "rowIndex": grid_dest["startRowIndex"],
                             "columnIndex": grid_dest["startColumnIndex"],
                         },
-                        "pasteType": paste_type.value,
+                        "pasteType": paste_type,
                     }
                 }
             ]

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1198,12 +1198,11 @@ class Worksheet:
 
         body = {
             "valueInputOption": value_input_option,
+            "includeValuesInResponse": include_values_in_response,
             "responseValueRenderOption": response_value_render_option,
             "responseDateTimeRenderOption": response_date_time_render_option,
+            "data": data,
         }
-
-        body["includeValuesInResponse"] = include_values_in_response
-        body["data"] = data
 
         response = self.client.values_batch_update(self.spreadsheet_id, body=body)
 
@@ -1695,10 +1694,8 @@ class Worksheet:
         params = {
             "valueInputOption": value_input_option,
             "insertDataOption": insert_data_option,
+            "includeValuesInResponse": include_values_in_response,
         }
-
-        # Not an Enum, does not pass `extract_enum_values`
-        params["includeValuesInResponse"] = include_values_in_response
 
         body = {"values": values}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Office/Business :: Financial :: Spreadsheet",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["google-auth>=1.12.0", "google-auth-oauthlib>=0.4.1"]
+dependencies = ["google-auth>=1.12.0", "google-auth-oauthlib>=0.4.1", "StrEnum==0.4.15"]
 requires-python = ">=3.7"
 dynamic = ["version", "description"]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ vcrpy
 pytest
 pytest-vcr
 urllib3==1.26.15
+StrEnum==0.4.15

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -1260,7 +1260,7 @@ class WorksheetTest(GspreadTest):
         col_groups = self.sheet.list_dimension_group_columns()
 
         range = col_groups[0]["range"]
-        self.assertEqual(range["dimension"], utils.Dimension.cols.value)
+        self.assertEqual(range["dimension"], utils.Dimension.cols)
         self.assertEqual(range["startIndex"], 0)
         self.assertEqual(range["endIndex"], 2)
 
@@ -1277,7 +1277,7 @@ class WorksheetTest(GspreadTest):
         row_groups = self.sheet.list_dimension_group_rows()
 
         range = row_groups[0]["range"]
-        self.assertEqual(range["dimension"], utils.Dimension.rows.value)
+        self.assertEqual(range["dimension"], utils.Dimension.rows)
         self.assertEqual(range["startIndex"], 0)
         self.assertEqual(range["endIndex"], 2)
 

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -1260,7 +1260,7 @@ class WorksheetTest(GspreadTest):
         col_groups = self.sheet.list_dimension_group_columns()
 
         range = col_groups[0]["range"]
-        self.assertEqual(range["dimension"], utils.Dimension.cols)
+        self.assertEqual(range["dimension"], utils.Dimension.cols.value)
         self.assertEqual(range["startIndex"], 0)
         self.assertEqual(range["endIndex"], 2)
 
@@ -1277,7 +1277,7 @@ class WorksheetTest(GspreadTest):
         row_groups = self.sheet.list_dimension_group_rows()
 
         range = row_groups[0]["range"]
-        self.assertEqual(range["dimension"], utils.Dimension.rows)
+        self.assertEqual(range["dimension"], utils.Dimension.rows.value)
         self.assertEqual(range["startIndex"], 0)
         self.assertEqual(range["endIndex"], 2)
 


### PR DESCRIPTION
Most of the parameters for the API are `ENUM`s

Replace the named tuples that are not fitted for that with enums.

Each enum hold one of the choices.
The actual string value must be extracted in order to pass strings only to the API using the function `extract_enum_value` using the `enum.value` field if the enum is not `None`.

this forces us to filter all arguments that are passed when they can possibly be `None`.

thought about setting the default value for each instead but this changes the API call made to the API and that could lead to unwanted behavior for the users.

Possible way was to add a new value to each enum: `default = None` which will result in a `None` value so it won't be part of the API call, but this requires all method to have that value as default value, and if a user (for some reason) sets one of the parameter to `param=None` then the code breaks and requires that user to change to `param=MyEnum.none` which is not user friendly. To me any function with default empty param should be either `None` or some default container like `param=[]` etc.

so far this is the less intrusive for users and keeps the API calls as is and use the default behavior from google.

closes #1222