### PR TITLE
Protect/unprotect

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ worksheet = sh.add_worksheet(title="A worksheet", rows="100", cols="20")
 sh.del_worksheet(worksheet)
 ```
 
+### Protecting / Unprotecting a Worksheet
+
+```python
+worksheet.protect()
+# Run your code without risk from other users (apart from the sheet owner!)
+worksheet.unprotect()
+```
+
 ### Getting a Cell Value
 
 ```python

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1910,6 +1910,7 @@ class Worksheet:
         description=None,
         warning_only=False,
         requesting_user_can_edit=False,
+        domain_users_can_edit=False,
     ):
         """Add protected range to the sheet. Only the editors can edit
         the protected range.
@@ -1962,6 +1963,7 @@ class Worksheet:
                             "editors": {
                                 "users": editor_users_emails,
                                 "groups": editor_groups_emails,
+                                "domainUsersCanEdit": domain_users_can_edit,
                             },
                         }
                     }
@@ -2964,3 +2966,22 @@ class Worksheet:
         }
 
         return self.spreadsheet.batch_update(body)
+
+    def column_count(self):
+        """Full English alias for .col_count"""
+        return self.col_count()
+
+    def list_protected_ranges(self):
+        """List protected ranges in current Worksheet"""
+        return self.spreadsheet.list_protected_ranges(self.id)
+
+    def protect(self):
+        """Protect all ranges in current Worksheet"""
+        email = get_email_from_somewhere_tbd()  # TODO ?
+        last_cell = rowcol_to_a1(self.row_count, self.col_count)
+        self.add_protected_range(f"A1:{last_cell}",email,description=f"LOCKED by {email}",)
+
+    def unprotect(self):
+        """Unprotect all ranges in current Worksheet"""
+        for range in self.list_protected_ranges(self.id):
+            self.delete_protected_range(range)


### PR DESCRIPTION
Relates to Issue #1208

- Added `Worksheet.protect` and `Worksheet.unprotect`.  I've suggested keeping the names 'protect' and 'unprotect' instead of 'protect_all' and 'unprotect_all' because the scope is already clear ie. the whole Worksheet, and this avoids extra typing.  The lack of arguments should also make it abundantly clear this doesn't protect/unprotect specific ranges.
- Still need a way of fetching `client.auth._service_account_email` to send to `Worksheet.add_protected_range()`.  This attribute seems to only be created on initialisation and I wasn't able to work out how to fetch it eg. from `auth`.  One approach might be to add `.email` attribute to `Spreadsheet` when object is first initialised?
- Added `domain_users_can_edit=False` as parameter to `Worksheet.add_protected_range()`.  Without it, a range is created but other (non system) users can still edit ie. not "View only" mode.
- Added `Worksheet.list_protected_ranges` as a helper method to match `Spreadsheet.list_protected_ranges` and avoid people having to know or guess code for the "round trip" ie. up to the parent spreadsheet, then back down to the original worksheet using id.
- Added `Worksheet.column_count` as alias for `.col_count`.  A pet peeve for many non-English speakers are abbreviations where an explicit (full English) variable name would avoid them having to guess.
- Not sure what tests to add - my test was visual inspection of the sample Worksheet: Is there a padlock icon on the specified sheet? Is the protected range shown in the right hand panel (Data - Protect sheets and ranges)?  This was what alerted me to things not working without 1domain_users_can_edit=False` (above).
- Updated README