### PR TITLE
feature/readme migration v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Google Spreadsheets Python API v4
 
 ![main workflow](https://img.shields.io/github/actions/workflow/status/burnash/gspread/main.yaml?logo=github)
-![github license](https://img.shields.io/pypi/l/gspread?logo=github)
-![latest download](https://img.shields.io/github/downloads-pre/burnash/gspread/latest/total?logo=github)
+![GitHub licence](https://img.shields.io/pypi/l/gspread?logo=github)
+![GitHub downloads](https://img.shields.io/github/downloads-pre/burnash/gspread/latest/total?logo=github)
 ![documentation](https://img.shields.io/readthedocs/gspread?logo=readthedocs)
-![pypi download](https://img.shields.io/pypi/dm/gspread?logo=pypi)
-![pypi version](https://img.shields.io/pypi/v/gspread?logo=pypi)
+![PyPi download](https://img.shields.io/pypi/dm/gspread?logo=pypi)
+![PyPi version](https://img.shields.io/pypi/v/gspread?logo=pypi)
 ![python version](https://img.shields.io/pypi/pyversions/gspread?style=pypi)
 
 Simple interface for working with Google Sheets.

--- a/README.md
+++ b/README.md
@@ -49,59 +49,51 @@ wks.update('B42', "it's down there somewhere, let me take another look.")
 wks.format('A1:B1', {'textFormat': {'bold': True}})
 ```
 
-## v6.0.0 migration
+## v5.12 to v6.0 Migration Guide
 
-### Silence warnings
+### Upgrade from Python 3.7
 
-In version 5 there are many warnings to mark deprecated feature/functions/methods.
-They can be silenced by setting the `GSPREAD_SILENCE_WARNINGS` environment variable to `1`
+Python 3.7 is [end-of-life](https://devguide.python.org/versions/). gspread v6 requires a minimum of Python 3.8.
+
+### Change `Worksheet.update` arguments
+
+The first two arguments (`values` & `range_name`) have swapped (to `range_name` & `values`). Either swap them (works in v6 only), or use named arguments (works in v5 & v6).
+
+As well, `values` can no longer be a list, and must be a 2D array.
+
+```diff
+- file.sheet1.update(["54"], "B2")
++ file.sheet1.update(range_name="I7", values=[["54"]])
+```
+
+### Change colours from dictionary to text
+
+v6 uses hexadecimal color representation. Change all colors to hex. You can use the compatibility function `gspread.utils.convert_colors_to_hex_value()` to convert a dictionary to a hex string.
+
+```diff
+- tab_color = {"red": 1, "green": 0.5, "blue": 1}
++ tab_color = "#FF7FFF"
+file.sheet1.update_tab_color(tab_color)
+```
 
 ### HTTP Client
 
-HTTP Clients have moved to a dedicated file. by default, gspread uses the `HTTPClient`.
-Also provided is a new `BackoffHTTPClient` , which retries failed requests with exponential time delay. It can be used with:
+HTTP Clients have moved to a dedicated file. By default, gspread uses the `HTTPClient`.
+Also provided is a new `BackoffHTTPClient`, which retries failed requests with exponential time delay. It can be used with:
 
 ```python
 client = gspread.service_account(http_client=gspread.http_client.BackOffHTTPClient)
 ```
-
-It works the same wayt for:
 
 - `gspread.service_account`
 - `gspread.oauth`
 - `gspread.service_account_from_dict`
 - `gspread.oauth_from_dict`
 
-### python-3.7 end-of-life
+### Silence warnings
 
-spread v6 no longer supports Python 3.7. The lowest supported version is Python 3.8.
-
-### `Worksheet.update` arguments have switched
-
-The method ``Worksheet.update()`` has changed it's signature. The arguments ``range_name`` and ``values`` have swapped.
-
-Please now use kwargs to assign arguments to be compatible with both v5.X.Y and v6.X.Y version.
-
-```python
-file.sheet1.update(range_name="I7", values=[["54"]])
-```
-
-the argument `values` must be a 2D list.
-
-### Colors now use hex representation
-
-GSpread now uses hexadecimal value to color a tab.
-
-You can use the utility function `gspread.utils.convert_colors_to_hex_value` to convert dict values to a single hexadecimal values.
-
-The method ``gspread.Worksheet.update_tab_color()` accepts both dict and string values.
-
-You can update you code as follows:
-
-```python
-tab_color = {"red": 1, "green": 0.1345, "blue": 1}
-file.sheet1.update_tab_color(convert_colors_to_hex_value(**tab_color))
-```
+In version 5 there are many warnings to mark deprecated feature/functions/methods.
+They can be silenced by setting the `GSPREAD_SILENCE_WARNINGS` environment variable to `1`
 
 ## More Examples
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Python-3.7 is now end-of-life, GSpread stopped supporting it.
 
 Lowest supported python version: 3.8
 
+### Method signature changes
+
+The method ``Worksheet.update()`` has changed it's signature. The arguments ``range_name`` and ``values`` have swapped.
+
+Please now use kwargs to assign arguments to be compatible with both v5.X.Y and v6.X.Y version.
+
+```python
+file.sheet1.update(range_name="I7", values=[["54"]])
+```
+
+#### Notice:
+
+the argument `values` must be a list of list !
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ file.sheet1.update(range_name="I7", values=[["54"]])
 
 the argument `values` must be a list of list !
 
+### New tab color usage
+
+GSpread now uses hexadecimal value to color a tab.
+
+You can use the utility function `gspread.utils.convert_colors_to_hex_value` to convert dict values to a single hexadecimal values.
+
+The method ``gspread.Worksheet.update_tab_color()` accepts both dict and string values.
+
+You can update you code as follow:
+
+```python
+tab_color = {"red": 1, "green": 0.1345, "blue": 1}
+file.sheet1.update_tab_color(convert_colors_to_hex_value(**tab_color))
+```
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Features:
 pip install gspread
 ```
 
-Requires Python 3.8+
+Requires Python 3.7+
 
 ## Basic Usage
 
 1. [Create credentials in Google API Console](http://gspread.readthedocs.org/en/latest/oauth2.html)
 
-2. Start using gspread:
+2. Start using gspread
 
 ```python
 import gspread

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ It works the same wayt for:
 - `gspread.service_account_from_dict`
 - `gspread.oauth_from_dict`
 
+### Stop support for python-3.7
+
+Python-3.7 is now end-of-life, GSpread stopped supporting it.
+
+Lowest supported python version: 3.8
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features:
 pip install gspread
 ```
 
-Requirements: Python 3.6+.
+Requires Python 3.8+
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -76,20 +76,6 @@ v6 uses hexadecimal color representation. Change all colors to hex. You can use 
 file.sheet1.update_tab_color(tab_color)
 ```
 
-### HTTP Client
-
-HTTP Clients have moved to a dedicated file. By default, gspread uses the `HTTPClient`.
-Also provided is a new `BackoffHTTPClient`, which retries failed requests with exponential time delay. It can be used with:
-
-```python
-client = gspread.service_account(http_client=gspread.http_client.BackOffHTTPClient)
-```
-
-- `gspread.service_account`
-- `gspread.oauth`
-- `gspread.service_account_from_dict`
-- `gspread.oauth_from_dict`
-
 ### Silence warnings
 
 In version 5 there are many warnings to mark deprecated feature/functions/methods.

--- a/README.md
+++ b/README.md
@@ -17,64 +17,6 @@ Features:
 - Sharing and access control.
 - Batching updates.
 
-## v6.0.0 migration
-
-### Silence the warnings
-
-In version 5 there are many warnings to mark deprecated feature/functions/methods.
-They can be silenced by setting the `GSPREAD_SILENCE_WARNINGS` environment variable to `1`
-
-### HTTP Client
-
-HTTP Clients have moved a dedicated file. GSpread uses by default the `HTTPClient`.
-If you wish to use the new `BackoffHTTPClient` please update your code as follow:
-
-```pythong
-client = gspread.service_account(http_client=gspread.http_client.BackOffHTTPClient)
-```
-
-It works the same wayt for:
-
-- `gspread.service_account`
-- `gspread.oauth`
-- `gspread.service_account_from_dict`
-- `gspread.oauth_from_dict`
-
-### Stop support for python-3.7
-
-Python-3.7 is now end-of-life, GSpread stopped supporting it.
-
-Lowest supported python version: 3.8
-
-### Method signature changes
-
-The method ``Worksheet.update()`` has changed it's signature. The arguments ``range_name`` and ``values`` have swapped.
-
-Please now use kwargs to assign arguments to be compatible with both v5.X.Y and v6.X.Y version.
-
-```python
-file.sheet1.update(range_name="I7", values=[["54"]])
-```
-
-#### Notice:
-
-the argument `values` must be a list of list !
-
-### New tab color usage
-
-GSpread now uses hexadecimal value to color a tab.
-
-You can use the utility function `gspread.utils.convert_colors_to_hex_value` to convert dict values to a single hexadecimal values.
-
-The method ``gspread.Worksheet.update_tab_color()` accepts both dict and string values.
-
-You can update you code as follow:
-
-```python
-tab_color = {"red": 1, "green": 0.1345, "blue": 1}
-file.sheet1.update_tab_color(convert_colors_to_hex_value(**tab_color))
-```
-
 ## Installation
 
 ```sh
@@ -105,6 +47,60 @@ wks.update('B42', "it's down there somewhere, let me take another look.")
 
 # Format the header
 wks.format('A1:B1', {'textFormat': {'bold': True}})
+```
+
+## v6.0.0 migration
+
+### Silence warnings
+
+In version 5 there are many warnings to mark deprecated feature/functions/methods.
+They can be silenced by setting the `GSPREAD_SILENCE_WARNINGS` environment variable to `1`
+
+### HTTP Client
+
+HTTP Clients have moved to a dedicated file. by default, gspread uses the `HTTPClient`.
+Also provided is a new `BackoffHTTPClient` , which retries failed requests with exponential time delay. It can be used with:
+
+```python
+client = gspread.service_account(http_client=gspread.http_client.BackOffHTTPClient)
+```
+
+It works the same wayt for:
+
+- `gspread.service_account`
+- `gspread.oauth`
+- `gspread.service_account_from_dict`
+- `gspread.oauth_from_dict`
+
+### python-3.7 end-of-life
+
+spread v6 no longer supports Python 3.7. The lowest supported version is Python 3.8.
+
+### `Worksheet.update` arguments have switched
+
+The method ``Worksheet.update()`` has changed it's signature. The arguments ``range_name`` and ``values`` have swapped.
+
+Please now use kwargs to assign arguments to be compatible with both v5.X.Y and v6.X.Y version.
+
+```python
+file.sheet1.update(range_name="I7", values=[["54"]])
+```
+
+the argument `values` must be a 2D list.
+
+### Colors now use hex representation
+
+GSpread now uses hexadecimal value to color a tab.
+
+You can use the utility function `gspread.utils.convert_colors_to_hex_value` to convert dict values to a single hexadecimal values.
+
+The method ``gspread.Worksheet.update_tab_color()` accepts both dict and string values.
+
+You can update you code as follows:
+
+```python
+tab_color = {"red": 1, "green": 0.1345, "blue": 1}
+file.sheet1.update_tab_color(convert_colors_to_hex_value(**tab_color))
 ```
 
 ## More Examples

--- a/README.md
+++ b/README.md
@@ -20,8 +20,25 @@ Features:
 ## v6.0.0 migration
 
 ### Silence the warnings
+
 In version 5 there are many warnings to mark deprecated feature/functions/methods.
 They can be silenced by setting the `GSPREAD_SILENCE_WARNINGS` environment variable to `1`
+
+### HTTP Client
+
+HTTP Clients have moved a dedicated file. GSpread uses by default the `HTTPClient`.
+If you wish to use the new `BackoffHTTPClient` please update your code as follow:
+
+```pythong
+client = gspread.service_account(http_client=gspread.http_client.BackOffHTTPClient)
+```
+
+It works the same wayt for:
+
+- `gspread.service_account`
+- `gspread.oauth`
+- `gspread.service_account_from_dict`
+- `gspread.oauth_from_dict`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ As well, `values` can no longer be a list, and must be a 2D array.
 + file.sheet1.update(range_name="I7", values=[["54"]])
 ```
 
-### Change colours from dictionary to text
+### Change colors from dictionary to text
 
 v6 uses hexadecimal color representation. Change all colors to hex. You can use the compatibility function `gspread.utils.convert_colors_to_hex_value()` to convert a dictionary to a hex string.
 
@@ -74,6 +74,13 @@ v6 uses hexadecimal color representation. Change all colors to hex. You can use 
 - tab_color = {"red": 1, "green": 0.5, "blue": 1}
 + tab_color = "#FF7FFF"
 file.sheet1.update_tab_color(tab_color)
+```
+
+### Switch lastUpdateTime from property to method
+
+```diff
+- age = spreadsheet.lastUpdateTime
++ age = spreadsheet.get_lastUpdateTime()
 ```
 
 ### Silence warnings


### PR DESCRIPTION
- Add HTTP client migration for v6
- No more python3.7
- update method signature change
- New usage of hex color for tab colors

I added a whole new section in the docs that we can keep for some time.

It was way too big to be only in the README, it took too much space.

We can keep pushing on this branch until we are complete. what do you think @alifeee  ?

Wtb at the end we need to add a link to the documentation in the README too but we can keep that for the last commit
