### PR TITLE
Fix list_spreadsheet_files return value

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,9 +22,7 @@
 To run tests, add your credentials to `tests/creds.json` and run
 
 ```bash
-GS_CREDS_FILENAME="tests/creds.json"
-GS_RECORD_MODE="all"
-tox -e py -- -k "<specific test to run>" -v -s
+GS_CREDS_FILENAME="tests/creds.json" GS_RECORD_MODE="all" tox -e py -- -k "<specific test to run>" -v -s
 ```
 
 For more information on tests, see below.

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -113,7 +113,7 @@ class Client:
 
     def list_spreadsheet_files(
         self, title=None, folder_id=None
-    ) -> Tuple[List[Dict[str, Any]], Response]:
+    ) -> List[Dict[str, Any]]:
         """List all the spreadsheet files
 
         Will list all spreadsheet files owned by/shared with this user account.
@@ -123,7 +123,15 @@ class Client:
             The parameter ``folder_id`` can be obtained from the URL when looking at
             a folder in a web browser as follow:
             ``https://drive.google.com/drive/u/0/folders/<folder_id>``
+
+        :returns: a list of dicts containing the keys id, name, createdTime and modifiedTime.
         """
+        files, _ = self._list_spreadsheet_files(title=title, folder_id=folder_id)
+        return files
+
+    def _list_spreadsheet_files(
+        self, title=None, folder_id=None
+    ) -> Tuple[List[Dict[str, Any]], Response]:
         files = []
         page_token = ""
         url = DRIVE_FILES_API_V3_URL
@@ -173,7 +181,7 @@ class Client:
 
         >>> gc.open('My fancy spreadsheet')
         """
-        spreadsheet_files, response = self.list_spreadsheet_files(title, folder_id)
+        spreadsheet_files, response = self._list_spreadsheet_files(title, folder_id)
         try:
             properties = finditem(
                 lambda x: x["name"] == title,
@@ -227,7 +235,7 @@ class Client:
 
         :returns: a list of :class:`~gspread.models.Spreadsheet` instances.
         """
-        spreadsheet_files, _ = self.list_spreadsheet_files(title)
+        spreadsheet_files = self.list_spreadsheet_files(title)
 
         if title:
             spreadsheet_files = [

--- a/tests/cassettes/ClientTest.test_list_spreadsheet_files.json
+++ b/tests/cassettes/ClientTest.test_list_spreadsheet_files.json
@@ -1,0 +1,330 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://www.googleapis.com/drive/v3/files?supportsAllDrives=True",
+                "body": "{\"name\": \"Test ClientTest test_list_spreadsheet_files\", \"mimeType\": \"application/vnd.google-apps.spreadsheet\"}",
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.31.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "x-goog-api-client": [
+                        "cred-type/sa"
+                    ],
+                    "x-allowed-locations": [
+                        "0x0"
+                    ],
+                    "Content-Length": [
+                        "110"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Vary": [
+                        "Origin, X-Origin"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ],
+                    "Date": [
+                        "Fri, 29 Sep 2023 19:39:06 GMT"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Expires": [
+                        "Mon, 01 Jan 1990 00:00:00 GMT"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "content-length": [
+                        "197"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"kind\": \"drive#file\",\n  \"id\": \"16x4eVnmuWxnblLaqAE7Z7qdztmy9lHruvJ_lvPQKNgc\",\n  \"name\": \"Test ClientTest test_list_spreadsheet_files\",\n  \"mimeType\": \"application/vnd.google-apps.spreadsheet\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://sheets.googleapis.com/v4/spreadsheets/16x4eVnmuWxnblLaqAE7Z7qdztmy9lHruvJ_lvPQKNgc?includeGridData=false",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.31.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "x-goog-api-client": [
+                        "cred-type/sa"
+                    ],
+                    "x-allowed-locations": [
+                        "0x0"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Vary": [
+                        "Origin",
+                        "X-Origin",
+                        "Referer"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Cache-Control": [
+                        "private"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ],
+                    "Date": [
+                        "Fri, 29 Sep 2023 19:39:06 GMT"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "x-l2-request-path": [
+                        "l2-managed-6"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "content-length": [
+                        "3341"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"spreadsheetId\": \"16x4eVnmuWxnblLaqAE7Z7qdztmy9lHruvJ_lvPQKNgc\",\n  \"properties\": {\n    \"title\": \"Test ClientTest test_list_spreadsheet_files\",\n    \"locale\": \"en_US\",\n    \"autoRecalc\": \"ON_CHANGE\",\n    \"timeZone\": \"Etc/GMT\",\n    \"defaultFormat\": {\n      \"backgroundColor\": {\n        \"red\": 1,\n        \"green\": 1,\n        \"blue\": 1\n      },\n      \"padding\": {\n        \"top\": 2,\n        \"right\": 3,\n        \"bottom\": 2,\n        \"left\": 3\n      },\n      \"verticalAlignment\": \"BOTTOM\",\n      \"wrapStrategy\": \"OVERFLOW_CELL\",\n      \"textFormat\": {\n        \"foregroundColor\": {},\n        \"fontFamily\": \"arial,sans,sans-serif\",\n        \"fontSize\": 10,\n        \"bold\": false,\n        \"italic\": false,\n        \"strikethrough\": false,\n        \"underline\": false,\n        \"foregroundColorStyle\": {\n          \"rgbColor\": {}\n        }\n      },\n      \"backgroundColorStyle\": {\n        \"rgbColor\": {\n          \"red\": 1,\n          \"green\": 1,\n          \"blue\": 1\n        }\n      }\n    },\n    \"spreadsheetTheme\": {\n      \"primaryFontFamily\": \"Arial\",\n      \"themeColors\": [\n        {\n          \"colorType\": \"TEXT\",\n          \"color\": {\n            \"rgbColor\": {}\n          }\n        },\n        {\n          \"colorType\": \"BACKGROUND\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 1,\n              \"blue\": 1\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT1\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.25882354,\n              \"green\": 0.52156866,\n              \"blue\": 0.95686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT2\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.91764706,\n              \"green\": 0.2627451,\n              \"blue\": 0.20784314\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT3\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.9843137,\n              \"green\": 0.7372549,\n              \"blue\": 0.015686275\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT4\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.20392157,\n              \"green\": 0.65882355,\n              \"blue\": 0.3254902\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT5\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 1,\n              \"green\": 0.42745098,\n              \"blue\": 0.003921569\n            }\n          }\n        },\n        {\n          \"colorType\": \"ACCENT6\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.27450982,\n              \"green\": 0.7411765,\n              \"blue\": 0.7764706\n            }\n          }\n        },\n        {\n          \"colorType\": \"LINK\",\n          \"color\": {\n            \"rgbColor\": {\n              \"red\": 0.06666667,\n              \"green\": 0.33333334,\n              \"blue\": 0.8\n            }\n          }\n        }\n      ]\n    }\n  },\n  \"sheets\": [\n    {\n      \"properties\": {\n        \"sheetId\": 0,\n        \"title\": \"Sheet1\",\n        \"index\": 0,\n        \"sheetType\": \"GRID\",\n        \"gridProperties\": {\n          \"rowCount\": 1000,\n          \"columnCount\": 26\n        }\n      }\n    }\n  ],\n  \"spreadsheetUrl\": \"https://docs.google.com/spreadsheets/d/16x4eVnmuWxnblLaqAE7Z7qdztmy9lHruvJ_lvPQKNgc/edit\"\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://www.googleapis.com/drive/v3/files?q=mimeType%3D%22application%2Fvnd.google-apps.spreadsheet%22&pageSize=1000&supportsAllDrives=True&includeItemsFromAllDrives=True&fields=kind%2CnextPageToken%2Cfiles%28id%2Cname%2CcreatedTime%2CmodifiedTime%29",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.31.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "x-goog-api-client": [
+                        "cred-type/sa"
+                    ],
+                    "x-allowed-locations": [
+                        "0x0"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Vary": [
+                        "Origin, X-Origin"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ],
+                    "Date": [
+                        "Fri, 29 Sep 2023 19:39:07 GMT"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Expires": [
+                        "Mon, 01 Jan 1990 00:00:00 GMT"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=UTF-8"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "content-length": [
+                        "280"
+                    ]
+                },
+                "body": {
+                    "string": "{\n  \"kind\": \"drive#fileList\",\n  \"files\": [\n    {\n      \"id\": \"16x4eVnmuWxnblLaqAE7Z7qdztmy9lHruvJ_lvPQKNgc\",\n      \"name\": \"Test ClientTest test_list_spreadsheet_files\",\n      \"createdTime\": \"2023-09-29T19:39:04.519Z\",\n      \"modifiedTime\": \"2023-09-29T19:39:05.549Z\"\n    }\n  ]\n}\n"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "uri": "https://www.googleapis.com/drive/v3/files/16x4eVnmuWxnblLaqAE7Z7qdztmy9lHruvJ_lvPQKNgc?supportsAllDrives=True",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "python-requests/2.31.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "x-goog-api-client": [
+                        "cred-type/sa"
+                    ],
+                    "x-allowed-locations": [
+                        "0x0"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "authorization": [
+                        "<ACCESS_TOKEN>"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 204,
+                    "message": "No Content"
+                },
+                "headers": {
+                    "Vary": [
+                        "Origin, X-Origin"
+                    ],
+                    "X-XSS-Protection": [
+                        "0"
+                    ],
+                    "Server": [
+                        "ESF"
+                    ],
+                    "Date": [
+                        "Fri, 29 Sep 2023 19:39:07 GMT"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Expires": [
+                        "Mon, 01 Jan 1990 00:00:00 GMT"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Content-Type": [
+                        "text/html"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Alt-Svc": [
+                        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        }
+    ]
+}

--- a/tests/cell_test.py
+++ b/tests/cell_test.py
@@ -51,14 +51,14 @@ class CellTest(GspreadTest):
         self.sheet.update_acell("A1", "= 1 / 1024")
         cell = self.sheet.acell("A1")
         self.assertEqual(cell.numeric_value, numeric_value)
-        self.assertTrue(isinstance(cell.numeric_value, float))
+        self.assertIsInstance(cell.numeric_value, float)
 
         # test value for popular format with long numbers
         numeric_value = 2000000.01
         self.sheet.update_acell("A1", "2,000,000.01")
         cell = self.sheet.acell("A1")
         self.assertEqual(cell.numeric_value, numeric_value)
-        self.assertTrue(isinstance(cell.numeric_value, float))
+        self.assertIsInstance(cell.numeric_value, float)
 
         # test non numeric value
         self.sheet.update_acell("A1", "Non-numeric value")

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -31,21 +31,21 @@ class ClientTest(GspreadTest):
 
         self.assertTrue(len(spreadsheet_list2) < len(spreadsheet_list))
         for s in spreadsheet_list:
-            self.assertTrue(isinstance(s, gspread.Spreadsheet))
+            self.assertIsInstance(s, gspread.Spreadsheet)
         for s in spreadsheet_list2:
-            self.assertTrue(isinstance(s, gspread.Spreadsheet))
+            self.assertIsInstance(s, gspread.Spreadsheet)
 
     @pytest.mark.vcr()
     def test_create(self):
         title = "Test Spreadsheet"
         new_spreadsheet = self.gc.create(title)
-        self.assertTrue(isinstance(new_spreadsheet, gspread.Spreadsheet))
+        self.assertIsInstance(new_spreadsheet, gspread.Spreadsheet)
 
     @pytest.mark.vcr()
     def test_copy(self):
         original_spreadsheet = self.spreadsheet
         spreadsheet_copy = self.gc.copy(original_spreadsheet.id)
-        self.assertTrue(isinstance(spreadsheet_copy, gspread.Spreadsheet))
+        self.assertIsInstance(spreadsheet_copy, gspread.Spreadsheet)
 
         original_metadata = original_spreadsheet.fetch_sheet_metadata()
         copy_metadata = spreadsheet_copy.fetch_sheet_metadata()
@@ -82,7 +82,7 @@ class ClientTest(GspreadTest):
         and that they all have metadata"""
         spreadsheets = self.gc.openall()
         for spreadsheet in spreadsheets:
-            self.assertTrue(isinstance(spreadsheet, gspread.Spreadsheet))
+            self.assertIsInstance(spreadsheet, gspread.Spreadsheet)
             # has properties that are not from Drive API (i.e., not title, id, creationTime)
             self.assertTrue(spreadsheet.locale)
             self.assertTrue(spreadsheet.timezone)
@@ -91,7 +91,7 @@ class ClientTest(GspreadTest):
     def test_open_by_key_has_metadata(self):
         """tests open_by_key has metadata"""
         spreadsheet = self.gc.open_by_key(self.spreadsheet.id)
-        self.assertTrue(isinstance(spreadsheet, gspread.Spreadsheet))
+        self.assertIsInstance(spreadsheet, gspread.Spreadsheet)
         # has properties that are not from Drive API (i.e., not title, id, creationTime)
         self.assertTrue(spreadsheet.locale)
         self.assertTrue(spreadsheet.timezone)
@@ -100,7 +100,7 @@ class ClientTest(GspreadTest):
     def test_open_by_name_has_metadata(self):
         """tests open has metadata"""
         spreadsheet = self.gc.open(self.spreadsheet.title)
-        self.assertTrue(isinstance(spreadsheet, gspread.Spreadsheet))
+        self.assertIsInstance(spreadsheet, gspread.Spreadsheet)
         # has properties that are not from Drive API (i.e., not title, id, creationTime)
         self.assertTrue(spreadsheet.locale)
         self.assertTrue(spreadsheet.timezone)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -25,6 +25,17 @@ class ClientTest(GspreadTest):
         self.assertRaises(gspread.SpreadsheetNotFound, self.gc.open, noexistent_title)
 
     @pytest.mark.vcr()
+    def test_list_spreadsheet_files(self):
+        res = self.gc.list_spreadsheet_files()
+        self.assertIsInstance(res, list)
+        for f in res:
+            self.assertIsInstance(f, dict)
+            self.assertIn("id", f)
+            self.assertIn("name", f)
+            self.assertIn("createdTime", f)
+            self.assertIn("modifiedTime", f)
+
+    @pytest.mark.vcr()
     def test_openall(self):
         spreadsheet_list = self.gc.openall()
         spreadsheet_list2 = self.gc.openall(spreadsheet_list[0].title)

--- a/tests/spreadsheet_test.py
+++ b/tests/spreadsheet_test.py
@@ -29,25 +29,25 @@ class SpreadsheetTest(GspreadTest):
     @pytest.mark.vcr()
     def test_sheet1(self):
         sheet1 = self.spreadsheet.sheet1
-        self.assertTrue(isinstance(sheet1, gspread.Worksheet))
+        self.assertIsInstance(sheet1, gspread.Worksheet)
 
     @pytest.mark.vcr()
     def test_get_worksheet(self):
         sheet1 = self.spreadsheet.get_worksheet(0)
-        self.assertTrue(isinstance(sheet1, gspread.Worksheet))
+        self.assertIsInstance(sheet1, gspread.Worksheet)
 
     @pytest.mark.vcr()
     def test_get_worksheet_by_id(self):
         sheet1_by_int = self.spreadsheet.get_worksheet_by_id(0)
         sheet1_by_str = self.spreadsheet.get_worksheet_by_id("0")
-        self.assertTrue(isinstance(sheet1_by_int, gspread.Worksheet))
-        self.assertTrue(isinstance(sheet1_by_str, gspread.Worksheet))
+        self.assertIsInstance(sheet1_by_int, gspread.Worksheet)
+        self.assertIsInstance(sheet1_by_str, gspread.Worksheet)
 
     @pytest.mark.vcr()
     def test_worksheet(self):
         sheet_title = "Sheet1"
         sheet = self.spreadsheet.worksheet(sheet_title)
-        self.assertTrue(isinstance(sheet, gspread.Worksheet))
+        self.assertIsInstance(sheet, gspread.Worksheet)
 
     @pytest.mark.vcr()
     def test_worksheets(self):

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -35,12 +35,12 @@ class WorksheetTest(GspreadTest):
     @pytest.mark.vcr()
     def test_acell(self):
         cell = self.sheet.acell("A1")
-        self.assertTrue(isinstance(cell, gspread.cell.Cell))
+        self.assertIsInstance(cell, gspread.cell.Cell)
 
     @pytest.mark.vcr()
     def test_cell(self):
         cell = self.sheet.cell(1, 1)
-        self.assertTrue(isinstance(cell, gspread.cell.Cell))
+        self.assertIsInstance(cell, gspread.cell.Cell)
 
     @pytest.mark.vcr()
     def test_range(self):
@@ -50,8 +50,8 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(len(cell_range1), 5)
 
         for c1, c2 in zip(cell_range1, cell_range2):
-            self.assertTrue(isinstance(c1, gspread.cell.Cell))
-            self.assertTrue(isinstance(c2, gspread.cell.Cell))
+            self.assertIsInstance(c1, gspread.cell.Cell)
+            self.assertIsInstance(c2, gspread.cell.Cell)
             self.assertTrue(c1.col == c2.col)
             self.assertTrue(c1.row == c2.row)
             self.assertTrue(c1.value == c2.value)


### PR DESCRIPTION
This pull request changes the return type of `list_spreadsheet_files` back to a list of dicts. A private method `_list_spreadsheet_files` does the heavy lifting and returns the tuple, to be consumed by `open`.

Fixes #1307 