### PR TITLE
Add type checking to lint

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,6 @@ jobs:
         if: ${{ matrix.python >= '3.8' }}
       - run: tox -e lint
       - run: tox -e py
-      - run: mypy --install-types --non-interactive --ignore-missing-imports ./gspread || true
       - run: shopt -s globstar && pyupgrade --py3-only **/*.py # --py36-plus
       - run: safety check -i 42559 # pip <= 20.1.1, we upgrade it just above
       - run: tox -e build

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -194,7 +194,7 @@ class Client:
         :returns: a :class:`~gspread.models.Spreadsheet` instance.
 
         """
-        payload = {
+        payload: Dict[str, Any] = {
             "name": title,
             "mimeType": MimeType.google_sheets,
         }
@@ -291,7 +291,7 @@ class Client:
         """
         url = "{}/{}/copy".format(DRIVE_FILES_API_V3_URL, file_id)
 
-        payload = {
+        payload: Dict[str, Any] = {
             "name": title,
             "mimeType": MimeType.google_sheets,
         }

--- a/gspread/http_client.py
+++ b/gspread/http_client.py
@@ -259,7 +259,7 @@ class HTTPClient:
         return r.json()
 
     def spreadsheets_sheets_copy_to(
-        self, id: str, sheet_id: str, destination_spreadsheet_id: str
+        self, id: str, sheet_id: int, destination_spreadsheet_id: str
     ) -> Any:
         """Lower-level method that directly calls `spreadsheets.sheets.copyTo <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.sheets/copyTo>`_."""
         url = SPREADSHEET_SHEETS_COPY_TO_URL % (id, sheet_id)

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -160,7 +160,7 @@ def finditem(func: Callable[[T], bool], seq: Iterable[T]) -> T:
 def numericise(
     value: Optional[AnyStr],
     empty2zero: bool = False,
-    default_blank: Optional[AnyStr] = "",
+    default_blank: Any = "",
     allow_underscores_in_numeric_literals: bool = False,
 ) -> Optional[Union[int, float, AnyStr]]:
     """Returns a value that depends on the input:
@@ -235,7 +235,7 @@ def numericise(
 def numericise_all(
     values: List[Optional[AnyStr]],
     empty2zero: bool = False,
-    default_blank: Optional[AnyStr] = "",
+    default_blank: Any = "",
     allow_underscores_in_numeric_literals: bool = False,
     ignore: List[int] = [],
 ) -> List[Optional[Union[int, float, AnyStr]]]:

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -95,7 +95,7 @@ class ExportFormat(StrEnum):
 class PasteType(StrEnum):
     normal = "PASTE_NORMAL"
     values = "PASTE_VALUES"
-    format = "PASTE_FORMAT"
+    format = "PASTE_FORMAT"  # type: ignore
     no_borders = "PASTE_NO_BORDERS"
     formula = "PASTE_NO_BORDERS"
     data_validation = "PASTE_DATA_VALIDATION"

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -1910,7 +1910,7 @@ class Worksheet:
         """
         range_label = absolute_range_name(self.title, table_range)
 
-        params = {
+        params: ParamsType = {
             "valueInputOption": value_input_option,
             "insertDataOption": insert_data_option,
             "includeValuesInResponse": include_values_in_response,
@@ -2025,7 +2025,7 @@ class Worksheet:
 
         range_label = absolute_range_name(self.title, "A%s" % row)
 
-        params = {"valueInputOption": value_input_option}
+        params: ParamsType = {"valueInputOption": value_input_option}
 
         body = {"majorDimension": Dimension.rows, "values": values}
 
@@ -2090,7 +2090,7 @@ class Worksheet:
 
         range_label = absolute_range_name(self.title, rowcol_to_a1(1, col))
 
-        params = {"valueInputOption": value_input_option}
+        params: ParamsType = {"valueInputOption": value_input_option}
 
         body = {"majorDimension": Dimension.cols, "values": values}
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -3,3 +3,6 @@ black==23.3.0
 codespell==2.2.5
 flake8==6.0.0
 isort==5.12.0
+mypy==1.6.1
+mypy-extensions==1.0.0
+typing_extensions==4.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands = black --check --diff --extend-exclude "./env" .
         codespell --skip=".tox,.git,./docs/build,.mypy_cache,./env" .
         flake8 .
         isort --check-only .
+        mypy --install-types --non-interactive --ignore-missing-imports ./gspread
 
 # Used by developers to format code, best advised to be run before commit
 [testenv:format]


### PR DESCRIPTION
closes #1321

I have added `mypy` type checking to the lint workflow, so it now runs when you run

```bash
tox -e lint
```

I also fixed some typing problems. `mypy` now runs without error.

Is there anything else to type @lavigne958? or is this everything?