### PR TITLE
fix type issue (remove `.first()` function)

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -310,10 +310,14 @@ class Worksheet:
         """
         try:
             data = self.get(
-                rowcol_to_a1(row, col), value_render_option=value_render_option
+                rowcol_to_a1(row, col),
+                value_render_option=value_render_option,
+                return_type=GridRangeType.ValueRange,
             )
-
-            value = str(data.first())
+            try:
+                value = str(data[0][0])
+            except IndexError:
+                value = str(None)
         except KeyError:
             value = ""
 


### PR DESCRIPTION
this was not caught by #1296's CI because type-checking was not yet enabled in the workflow.

This is the main change:

```diff
- value = str(data.first())
+ try:
+     value = str(data[0][0])
+ except IndexError:
+     value = str(None)
```

...which replaces the call to `ValueRange.first()` with its implementation

https://github.com/burnash/gspread/blob/6944c1f94f29279b5412ba2e0606276ddbb1ad09/gspread/worksheet.py#L140-L148

The error was because before #1296, `get` returned a `ValueRange`. *After* #1296, it returns `ValueRange | List[List[Any]]`, so the type checking complained that `.first()` was not a method on `List[List[Any]]`. I'm not sure how to solve this issue by typinig, which is why I did what I did here.

Why is `.first()` needed as a function anyway? It is hardly used. I propose that we don't need it (but we should keep it, and just not use it internally).