### PR TITLE
feature/merge master

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.x"]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -U pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
     - name: Setup tox

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,12 @@
 Release History
 ===============
 
-5.12.1 (2023-12-04)
+5.12.3 (2023-12-15)
+-------------------
+
+* 1363 get all records retrieves a large number of empty rows after the end of the data by @alifeee in https://github.com/burnash/gspread/pull/1364
+
+5.12.2 (2023-12-04)
 -------------------
 
 * Many fixes for `get_records` by @alifeee in https://github.com/burnash/gspread/pull/1357


### PR DESCRIPTION
- correct history version
- release 5.12.3
- ignore pip security vulnerabilities see https://github.com/burnash/gspread/pull/1371#discussion_r1427445954
- Bump actions/setup-python from 4 to 5
