### PR TITLE
Remove-py-3.7-support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ classifiers = [
     "Topic :: Office/Business :: Financial :: Spreadsheet",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["google-auth>=1.12.0", "google-auth-oauthlib>=0.4.1", "StrEnum==0.4.15"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ keywords = ["spreadsheets", "google-spreadsheets", "google-sheets"]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -27,6 +26,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Office/Business :: Financial :: Spreadsheet",
     "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "google-auth>=1.12.0",
+    "google-auth-oauthlib>=0.4.1",
+    "StrEnum==0.4.15",
 ]
 requires-python = ">=3.8"
 dynamic = ["version", "description"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,py312
+envlist = py38,py39,py310,py311,py312
 skip_missing_interpreters = true
 
 # Used to run tests, **do not** set GS_CREDS_FILENAME to run off-line tests


### PR DESCRIPTION
It was removed already by #1234.

It found its way back in, somehow.

closes #1391