### PR TITLE
check oauth creds type using `isinstance`

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -189,7 +189,7 @@ def oauth(
     authorized_user_filename = Path(authorized_user_filename)
     creds = load_credentials(filename=authorized_user_filename)
 
-    if not isinstance(creds, OAuthCredentials):
+    if not isinstance(creds, Credentials):
         with open(credentials_filename) as json_file:
             client_config = json.load(json_file)
         creds = flow(client_config=client_config, scopes=scopes)

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -189,7 +189,7 @@ def oauth(
     authorized_user_filename = Path(authorized_user_filename)
     creds = load_credentials(filename=authorized_user_filename)
 
-    if not type(creds) is Credentials:
+    if not isinstance(creds, OAuthCredentials):
         with open(credentials_filename) as json_file:
             client_config = json.load(json_file)
         creds = flow(client_config=client_config, scopes=scopes)


### PR DESCRIPTION
closes #1390

Credentials object is renamed `OAuthCredentials` in v6.0.0, and is no longer `Credentials` type, so the type-check for "already logged in" was failing. See https://github.com/burnash/gspread/issues/1390#issuecomment-1919494986 for more context.

It is worth noting that types were being checked with `type()`. This it not reccomended as per [pylint](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/unidiomatic-typecheck.html).

If we had been using `isinstance`, this bug would not appear, as

`if not type(creds) is Credentials:` did not work with `OAuthCredentials`
`if not isinstance(creds, Credentials):` would have worked with `OAuthCredentials` as it is a subclass of `Credentials`

- [ ] I do not know enough about `oauth` to add an adequate test so that this problem does not happen again
- [ ] I do not know enough about `oauth` to know if this renaming of `Credentials` -> `OAuthCredentials` could have other problems in `auth.py` or elsewhere

Thus, the result of this change is only tested manually, by me, on my computer.... :/