### PR TITLE
Fix type hints at find method in worksheet.py

### DIFF
--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -2259,8 +2259,8 @@ class Worksheet:
     def find(
         self,
         query: Union[str, re.Pattern],
-        in_row: Optional[bool] = None,
-        in_column: Optional[bool] = None,
+        in_row: Optional[int] = None,
+        in_column: Optional[int] = None,
         case_sensitive: bool = True,
     ) -> Optional[Cell]:
         """Finds the first cell matching the query.


### PR DESCRIPTION
Hi, I changed the type hints for the `in_row` and `in_column` arguments of the find method in `worksheet.py` from `Optional[bool]` to `Optional[int]`. 

Could you check this later?