### PR TITLE
Fixup gspread client init arguments

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -77,7 +77,7 @@ def authorize(
     :rtype: :class:`gspread.client.Client`
     """
 
-    return Client(auth=credentials, http_client=http_client, session=session)
+    return Client(auth=credentials, session=session, http_client=http_client)
 
 
 class FlowCallable(Protocol):

--- a/gspread/client.py
+++ b/gspread/client.py
@@ -38,8 +38,8 @@ class Client:
     def __init__(
         self,
         auth: Credentials,
-        http_client: HTTPClientType = HTTPClient,
         session: Optional[Session] = None,
+        http_client: HTTPClientType = HTTPClient,
     ) -> None:
         self.http_client = http_client(auth, session)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def client():
     else:
         auth_credentials = DummyCredentials(DUMMY_ACCESS_TOKEN)
 
-    gc = Client(auth_credentials, BackOffHTTPClient)
+    gc = Client(auth=auth_credentials, http_client=BackOffHTTPClient)
     if not isinstance(gc, gspread.client.Client) is True:
         raise AssertionError
 


### PR DESCRIPTION
In order to be backward compatible re-order gspread client init
arguments, and assign a default value to the new argument.

closes #1411

Signed-off-by: Alexandre Lavigne <lavigne958@gmail.com>
