### PR TITLE
Add py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ file = "LICENSE.txt"
 
 [tool.flit.sdist]
 include = ["docs/", "HISTORY.rst"]
+
+[tool.setuptools.package-data]
+gspread = ["gspread/py.typed"]


### PR DESCRIPTION
Adding the marker file `py.typed` allows users to type their project and read the typing from gspread

closes #1401