### PR TITLE
Add missing method `import_csv()`

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -15,11 +15,7 @@ from requests import Response, Session
 from .exceptions import APIError, SpreadsheetNotFound
 from .http_client import HTTPClient, HTTPClientType, ParamsType
 from .spreadsheet import Spreadsheet
-from .urls import (
-    DRIVE_FILES_API_V3_COMMENTS_URL,
-    DRIVE_FILES_API_V3_URL,
-    DRIVE_FILES_UPLOAD_API_V2_URL,
-)
+from .urls import DRIVE_FILES_API_V3_COMMENTS_URL, DRIVE_FILES_API_V3_URL
 from .utils import ExportFormat, MimeType, extract_id_from_url, finditem
 
 
@@ -353,7 +349,7 @@ class Client:
         params: ParamsType = {"supportsAllDrives": True}
         self.http_client.request("delete", url, params=params)
 
-    def import_csv(self, file_id: str, data: Union[str, bytes]) -> None:
+    def import_csv(self, file_id: str, data: Union[str, bytes]) -> Any:
         """Imports data into the first page of the spreadsheet.
 
         :param str file_id:
@@ -374,24 +370,7 @@ class Client:
            replaces the contents of the first worksheet.
 
         """
-        # Make sure we send utf-8
-        if type(data) is str:
-            payload = data.encode("utf-8")
-
-        headers = {"Content-Type": "text/csv"}
-        url = "{}/{}".format(DRIVE_FILES_UPLOAD_API_V2_URL, file_id)
-
-        self.http_client.request(
-            "put",
-            url,
-            data=bytes(payload),
-            params={
-                "uploadType": "media",
-                "convert": True,
-                "supportsAllDrives": True,
-            },
-            headers=headers,
-        )
+        return self.http_client.import_csv(file_id, data)
 
     def list_permissions(self, file_id: str) -> List[Dict[str, Union[str, bool]]]:
         """Retrieve a list of permissions for a file.

--- a/gspread/http_client.py
+++ b/gspread/http_client.py
@@ -6,6 +6,7 @@ This module contains HTTPClient class responsible for communicating with
 Google API.
 
 """
+
 import time
 from http import HTTPStatus
 from typing import (
@@ -28,6 +29,7 @@ from requests import Response, Session
 from .exceptions import APIError, UnSupportedExportFormat
 from .urls import (
     DRIVE_FILES_API_V3_URL,
+    DRIVE_FILES_UPLOAD_API_V2_URL,
     SPREADSHEET_BATCH_UPDATE_URL,
     SPREADSHEET_SHEETS_COPY_TO_URL,
     SPREADSHEET_URL,
@@ -464,6 +466,47 @@ class HTTPClient:
 
         params: ParamsType = {"supportsAllDrives": True}
         self.request("delete", url, params=params)
+
+    def import_csv(self, file_id: str, data: Union[str, bytes]) -> Any:
+        """Imports data into the first page of the spreadsheet.
+
+        :param str data: A CSV string of data.
+
+        Example:
+
+        .. code::
+
+            # Read CSV file contents
+            content = open('file_to_import.csv', 'r').read()
+
+            gc.import_csv(spreadsheet.id, content)
+
+        .. note::
+
+           This method removes all other worksheets and then entirely
+           replaces the contents of the first worksheet.
+
+        """
+        # Make sure we send utf-8
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+
+        headers = {"Content-Type": "text/csv"}
+        url = "{}/{}".format(DRIVE_FILES_UPLOAD_API_V2_URL, file_id)
+
+        res = self.request(
+            "put",
+            url,
+            data=data,
+            params={
+                "uploadType": "media",
+                "convert": True,
+                "supportsAllDrives": True,
+            },
+            headers=headers,
+        )
+
+        return res.json()
 
 
 class BackOffHTTPClient(HTTPClient):

--- a/gspread/utils.py
+++ b/gspread/utils.py
@@ -58,9 +58,6 @@ class MergeType(StrEnum):
     merge_rows = "MERGE_ROWS"
 
 
-SILENCE_WARNINGS_ENV_KEY = "GSPREAD_SILENCE_WARNINGS"
-
-
 class ValueRenderOption(StrEnum):
     formatted = "FORMATTED_VALUE"
     unformatted = "UNFORMATTED_VALUE"
@@ -270,13 +267,15 @@ def numericise_all(
     ignore = ignore or []
 
     numericised_list = [
-        values[index]
-        if index + 1 in ignore
-        else numericise(
-            values[index],
-            empty2zero=empty2zero,
-            default_blank=default_blank,
-            allow_underscores_in_numeric_literals=allow_underscores_in_numeric_literals,
+        (
+            values[index]
+            if index + 1 in ignore
+            else numericise(
+                values[index],
+                empty2zero=empty2zero,
+                default_blank=default_blank,
+                allow_underscores_in_numeric_literals=allow_underscores_in_numeric_literals,
+            )
         )
         for index in range(len(values))
     ]
@@ -917,6 +916,14 @@ def to_records(
 
 
 # SHOULD NOT BE NEEDED UNTIL NEXT MAJOR VERSION
+# DEPRECATION_WARNING_TEMPLATE = (
+#     "[Deprecated][in version {v_deprecated}]: {msg_deprecated}"
+# )
+
+
+# SILENCE_WARNINGS_ENV_KEY = "GSPREAD_SILENCE_WARNINGS"
+
+
 # def deprecation_warning(version: str, msg: str) -> None:
 #     """Emit a deprecation warning.
 


### PR DESCRIPTION
Prior to v6.x.y the method could be used as follow:

file = client.open('x')
file.client.import_csv()

Now file.client is of type HTTPClient
so we need to add the method back for backward compatibility

closes #1423