### PR TITLE
Add pypi trusted publisher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    environment: release
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -36,11 +39,6 @@ jobs:
     - name: Publish to TestPyPi
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
     - name: Publish to PyPi
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Remove use of token, use Pypi OIDC from github.

closes #1331