### PR TITLE
More fixes for `Worksheet.update` argument ordering & single cell updating (i.e. now `Worksheet.update_acell`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ cell_list = worksheet.findall(criteria_re)
 
 ```python
 # Update a single cell
-worksheet.update_acell('Bingo!', 'B1')
+worksheet.update_acell('B1', 'Bingo!')
 
 # Update a range
 worksheet.update([[1, 2], [3, 4]], 'A1:B2')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,10 +36,10 @@ Quick Example
    wks = gc.open("Where is the money Lebowski?").sheet1
 
    # Update a range of cells using the top left corner address
-   wks.update('A1', [[1, 2], [3, 4]])
+   wks.update([[1, 2], [3, 4]], 'A1')
 
    # Or update a single cell
-   wks.update('B42', "it's down there somewhere, let me take another look.")
+   wks.update_acell('B42', "it's down there somewhere, let me take another look.")
 
    # Format the header
    wks.format('A1:B1', {'textFormat': {'bold': True}})

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -302,7 +302,7 @@ Using `A1 notation <https://developers.google.com/sheets/api/guides/concepts#a1_
 
 .. code:: python
 
-   worksheet.update('B1', 'Bingo!')
+   worksheet.update_acell('B1', 'Bingo!')
 
 Or row and column coordinates:
 
@@ -314,7 +314,7 @@ Update a range
 
 .. code:: python
 
-   worksheet.update('A1:B2', [[1, 2], [3, 4]])
+   worksheet.update([[1, 2], [3, 4]], 'A1:B2')
 
 Formatting
 ~~~~~~~~~~
@@ -402,5 +402,5 @@ Write a NumPy array to a sheet:
    array = np.array([[1, 2, 3], [4, 5, 6]])
 
    # Write the array to worksheet starting from the A2 cell
-   worksheet.update('A2', array.tolist())
+   worksheet.update(array.tolist(), 'A2')
 

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -163,7 +163,7 @@ def oauth(
         gc = gspread.oauth(scopes=gspread.auth.READONLY_SCOPES)
 
         sh = gc.open("A spreadsheet")
-        sh.sheet1.update('A1', '42')   # <-- this will not work
+        sh.sheet1.update_acell('A1', '42')   # <-- this will not work
 
     If you're storing your user credentials in a place other than the
     default, you may provide a path to that file like so::
@@ -246,7 +246,7 @@ def oauth_from_dict(
         gc = gspread.oauth_from_dict(scopes=gspread.auth.READONLY_SCOPES)
 
         sh = gc.open("A spreadsheet")
-        sh.sheet1.update('A1', '42')   # <-- this will not work
+        sh.sheet1.update_acell('A1', '42')   # <-- this will not work
 
     This function requires you to pass the credentials directly as
     a python dict. After the first authentication the function returns

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -315,7 +315,7 @@ class WorksheetTest(GspreadTest):
             ["", "4", "", ""],
             ["", "5", "", ""],
         ]
-        self.sheet.update("A1:D4", sheet_data)
+        self.sheet.update(sheet_data, "A1:D4")
         self.sheet.merge_cells("A1:B2", utils.MergeType.merge_all)
         self.sheet.merge_cells("C1:D2", utils.MergeType.merge_columns)
         self.sheet.merge_cells("B3:C4", utils.MergeType.merge_rows)


### PR DESCRIPTION
Fixes similar to #1431  for docs, a docstring and a test.

- `Worksheet.update` default argument ordering is now `Worksheet.update(<values>, <range name>, ...`
- Single cell updating uses the `Worksheet.update_acell` method now
