### PR TITLE
bugfix: handle domain name in spreadsheet copy permissions

### DIFF
--- a/gspread/client.py
+++ b/gspread/client.py
@@ -317,8 +317,18 @@ class Client:
                 if p.get("deleted"):
                     continue
 
+                # In case of domain type the domain extract the domain
+                # In case of user/group extract the emailAddress
+                # Otherwise use None for type 'Anyone'
+
+                email_or_domain = ""
+                if str(p["type"]) == "domain":
+                    email_or_domain = str(p["domain"])
+                elif str(p["type"]) in ("user", "group"):
+                    email_or_domain = str(p["emailAddress"])
+
                 new_spreadsheet.share(
-                    email_address=str(p["emailAddress"]),
+                    email_address=email_or_domain,
                     perm_type=str(p["type"]),
                     role=str(p["role"]),
                     notify=False,


### PR DESCRIPTION
When a user request to copy a spreadsheet it can request to copy the source spreadsheet permissions too.

When copying the permissions these could be of type:
- Anyone (no email address)
- User or Group: an email address exists
- Domain: no email address exists but a domain instead

extract the right information and pass it to the lower level method that will handle it depending on the type.

closes #1457