### PR TITLE
Fix/api key auth version

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -12,8 +12,10 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Protocol, Tuple, Union
 
 from google.auth.credentials import Credentials
+
 try:
     from google.auth.api_key import Credentials as APIKeyCredentials
+
     GOOGLE_AUTH_API_KEY_AVAILABLE = True
 except ImportError:
     GOOGLE_AUTH_API_KEY_AVAILABLE = False
@@ -384,6 +386,8 @@ def api_key(token: str, http_client: HTTPClientType = HTTPClient) -> Client:
 
     """
     if GOOGLE_AUTH_API_KEY_AVAILABLE is False:
-        raise NotImplementedError(f'api_key is only available with package google.auth>=2.4.0. Install it with "pip install google-auth>=2.4.0".')
+        raise NotImplementedError(
+            f'api_key is only available with package google.auth>=2.4.0. Install it with "pip install google-auth>=2.4.0".'
+        )
     creds = APIKeyCredentials(token)
     return Client(auth=creds, http_client=http_client)

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -387,7 +387,8 @@ def api_key(token: str, http_client: HTTPClientType = HTTPClient) -> Client:
     """
     if GOOGLE_AUTH_API_KEY_AVAILABLE is False:
         raise NotImplementedError(
-            f'api_key is only available with package google.auth>=2.4.0. Install it with "pip install google-auth>=2.4.0".'
+            "api_key is only available with package google.auth>=2.4.0."
+            'Install it with "pip install google-auth>=2.4.0".'
         )
     creds = APIKeyCredentials(token)
     return Client(auth=creds, http_client=http_client)

--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -11,8 +11,12 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Protocol, Tuple, Union
 
-from google.auth.api_key import Credentials as APIKeyCredentials
 from google.auth.credentials import Credentials
+try:
+    from google.auth.api_key import Credentials as APIKeyCredentials
+    GOOGLE_AUTH_API_KEY_AVAILABLE = True
+except ImportError:
+    GOOGLE_AUTH_API_KEY_AVAILABLE = False
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as SACredentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -379,5 +383,7 @@ def api_key(token: str, http_client: HTTPClientType = HTTPClient) -> Client:
     :rtype: :class:`gspread.client.Client`
 
     """
+    if GOOGLE_AUTH_API_KEY_AVAILABLE is False:
+        raise NotImplementedError(f'api_key is only available with package google.auth>=2.4.0. Install it with "pip install google-auth>=2.4.0".')
     creds = APIKeyCredentials(token)
     return Client(auth=creds, http_client=http_client)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-google-auth==2.15.0
-google-auth-oauthlib>=0.8.0
+google-auth==1.12.0
+google-auth-oauthlib==0.4.1
 vcrpy
 pytest
 pytest-vcr


### PR DESCRIPTION
closes #1454 

changing `test-requirements.txt` means that the tests for `api_key` auth *do* fail.

Adding the "fix" means the tests "work" (they do not throw an exception)