### PR TITLE
Ignore pip vulnerabilities in CI.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,6 +30,6 @@ jobs:
       - run: tox -e lint
       - run: tox -e py
       - run: shopt -s globstar && pyupgrade --py3-only **/*.py # --py36-plus
-      - run: safety check -i 42559 -i 62044 # pip <= 20.1.1, we upgrade it just above
+      - run: safety check -i 42559 -i 62044 -i 67599 # pip version issue, we don't care about it, we don't ship it
       - run: tox -e build
       - run: tox -e doc


### PR DESCRIPTION
ignore pip vulnerabilities in CI, we don't ship pip. 