### PR TITLE
Fix code block formatting typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ from gspread.utils import ValueRenderOption
 # Get formula from a cell
 >>> worksheet.get("C2:D2", value_render_option=ValueRenderOption.formula)
 [['=1/1024']]
+```
+
 ### Add data validation to a range
 
 ```python
@@ -315,7 +317,6 @@ worksheet.add_validation(
    'No',]
    showCustomUi=True
 )
-
 ```
 
 ## Documentation


### PR DESCRIPTION
Small fix to correct formatting of code block example in README for "Add data validation to a range".

Before:
<img width="1051" alt="before" src="https://github.com/burnash/gspread/assets/81984973/a9ed08b8-d47a-4f31-ae49-31f09993c4d9">

After:
<img width="1043" alt="after" src="https://github.com/burnash/gspread/assets/81984973/1e27ab76-1975-48ef-b276-b6d01a28f0e0">
