### PR TITLE
Remove passing exception as args to super in APIError

### DIFF
--- a/gspread/exceptions.py
+++ b/gspread/exceptions.py
@@ -40,9 +40,10 @@ class APIError(GSpreadException):
     such as when we attempt to retrieve things that don't exist."""
 
     def __init__(self, response: Response):
-        super().__init__(response)
+        error = dict(response.json()["error"])
+        super().__init__(error)
         self.response: Response = response
-        self.error: Mapping[str, Any] = response.json()["error"]
+        self.error: Mapping[str, Any] = error
         self.code: int = self.error["code"]
 
     def __str__(self) -> str:
@@ -52,6 +53,9 @@ class APIError(GSpreadException):
 
     def __repr__(self) -> str:
         return self.__str__()
+
+    def __reduce__(self) -> tuple:
+        return self.__class__, (self.response,)
 
 
 class SpreadsheetNotFound(GSpreadException):

--- a/gspread/exceptions.py
+++ b/gspread/exceptions.py
@@ -40,7 +40,7 @@ class APIError(GSpreadException):
     such as when we attempt to retrieve things that don't exist."""
 
     def __init__(self, response: Response):
-        super().__init__(self._extract_error(response))
+        super().__init__(response)
         self.response: Response = response
         self.error: Mapping[str, Any] = response.json()["error"]
         self.code: int = self.error["code"]

--- a/gspread/exceptions.py
+++ b/gspread/exceptions.py
@@ -6,7 +6,7 @@ Exceptions used in gspread.
 
 """
 
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Mapping
 
 from requests import Response
 
@@ -44,15 +44,6 @@ class APIError(GSpreadException):
         self.response: Response = response
         self.error: Mapping[str, Any] = response.json()["error"]
         self.code: int = self.error["code"]
-
-    def _extract_error(
-        self, response: Response
-    ) -> Optional[Dict[str, Union[int, str]]]:
-        try:
-            errors = response.json()
-            return dict(errors["error"])
-        except (AttributeError, KeyError, ValueError):
-            return None
 
     def __str__(self) -> str:
         return "{}: [{}]: {}".format(

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -1915,5 +1915,7 @@ class WorksheetTest(GspreadTest):
         with self.assertRaises(APIError) as ex:
             sheet.update(values="X", range_name="A1")
 
-        # Ensure that the exception is able to be pickled
-        pickle.loads(pickle.dumps(ex.exception))  # nosec
+        # Ensure that the exception is able to be pickled and unpickled
+        # Further ensure we are able to access the exception's properties after pickling
+        reloaded_exception = pickle.loads(pickle.dumps(ex.exception))  # nosec
+        self.assertEqual(reloaded_exception.args[0]["status"], "INVALID_ARGUMENT")

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -1,4 +1,5 @@
 import itertools
+import pickle
 import random
 import re
 from inspect import signature
@@ -1911,4 +1912,8 @@ class WorksheetTest(GspreadTest):
             {"spreadsheetId": self.spreadsheet.id, "replies": [{}]},
         )
 
-        self.assertRaises(APIError, sheet.update, values="X", range_name="A1")
+        with self.assertRaises(APIError) as ex:
+            sheet.update(values="X", range_name="A1")
+
+        # Ensure that the exception is able to be pickled
+        pickle.loads(pickle.dumps(ex.exception))

--- a/tests/worksheet_test.py
+++ b/tests/worksheet_test.py
@@ -1,5 +1,5 @@
 import itertools
-import pickle
+import pickle  # nosec
 import random
 import re
 from inspect import signature
@@ -1916,4 +1916,4 @@ class WorksheetTest(GspreadTest):
             sheet.update(values="X", range_name="A1")
 
         # Ensure that the exception is able to be pickled
-        pickle.loads(pickle.dumps(ex.exception))
+        pickle.loads(pickle.dumps(ex.exception))  # nosec


### PR DESCRIPTION
First, thanks for this tool!

We have a pipeline where exceptions from packages such as `gspread` are pickled and stored for further processing. Unfortunately, the `APIError` exception is not able to be unpickled as the args it passed to the `Exception` super are different from what is passed into the exception itself.

The sample test extension exposes this error as seen below:
```
    def __init__(self, response: Response):
        super().__init__(self._extract_error(response))
        self.response: Response = response
>       self.error: Mapping[str, Any] = response.json()["error"]
E       AttributeError: 'dict' object has no attribute 'json'

gspread/exceptions.py:45: AttributeError
```

This PR ultimately only replaces the extracted error with the raw response passed to the kwargs. Given that `__str__` and `__repr__` are overloaded and all other usage of this exception use the other members, there is no visible impact from this change.