### PR TITLE
Fix comment to reflect correct google-auth package version requirement

### DIFF
--- a/gspread/auth.py
+++ b/gspread/auth.py
@@ -386,8 +386,8 @@ def api_key(token: str, http_client: HTTPClientType = HTTPClient) -> Client:
     """
     if GOOGLE_AUTH_API_KEY_AVAILABLE is False:
         raise NotImplementedError(
-            "api_key is only available with package google.auth>=2.4.0."
-            'Install it with "pip install google-auth>=2.4.0".'
+            "api_key is only available with package google.auth>=2.15.0. "
+            'Install it with "pip install google-auth>=2.15.0".'
         )
     creds = APIKeyCredentials(token)
     return Client(auth=creds, http_client=http_client)


### PR DESCRIPTION
#### Changes
- Updated the comment in `gspread/auth.py` to indicate that the `api_key` feature is available starting from `google-auth` version `2.15.0`.

#### Context
The previous comment incorrectly stated that the `api_key` feature was available from version `2.4.0`. This has been corrected to `2.15.0`.

#### Screenshots
- **v2.14.1**: 
<img width="1210" alt="Screenshot 2024-08-08 at 10 03 06" src="https://github.com/user-attachments/assets/89ac0093-cd1e-4fe7-9b10-c12b162e4201">

- **v2.15.0**: 
<img width="990" alt="Screenshot 2024-08-08 at 10 03 25" src="https://github.com/user-attachments/assets/b786ba50-1203-4fb6-a9ec-c7b24642c50d">
