### PR TITLE
explicitly list top-level exports

### DIFF
--- a/gspread/__init__.py
+++ b/gspread/__init__.py
@@ -24,3 +24,25 @@ from .exceptions import (
 from .http_client import BackOffHTTPClient, HTTPClient
 from .spreadsheet import Spreadsheet
 from .worksheet import ValueRange, Worksheet
+
+# https://peps.python.org/pep-0008/#public-and-internal-interfaces
+__all__ = [
+    "api_key",
+    "authorize",
+    "oauth",
+    "oauth_from_dict",
+    "service_account",
+    "service_account_from_dict",
+    "Cell",
+    "Client",
+    "GSpreadException",
+    "IncorrectCellLabel",
+    "NoValidUrlKeyFound",
+    "SpreadsheetNotFound",
+    "WorksheetNotFound",
+    "BackOffHTTPClient",
+    "HTTPClient",
+    "Spreadsheet",
+    "ValueRange",
+    "Worksheet",
+]


### PR DESCRIPTION
Fixes Pylance/Pyright reporting `"oauth" is not exported from module "gspread"` when using `gspread.oauth()` (for example). Screenshot from VSCode:

<img width="996" alt="image" src="https://github.com/user-attachments/assets/5d6b0ae7-73f8-492e-8bbc-dadb346b40b3" />

[More about the warning.](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage)

Note that I have not tested the change.