### PR TITLE
Support Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.x"]
+        python: ["3.9", "3.10", "3.11", "3.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -26,7 +26,7 @@ jobs:
       - run: pip install -U pip
       - run: pip install -U bandit mypy pyupgrade safety tox setuptools
       - run: bandit --recursive --skip B105,B110,B311,B605,B607 --exclude ./.tox .
-        if: ${{ matrix.python >= '3.8' }}
+        if: ${{ matrix.python >= '3.9' }}
       - run: tox -e lint
       - run: tox -e py
       - run: shopt -s globstar && pyupgrade --py3-only **/*.py # --py36-plus

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.x"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Setup tox
       run: pip install tox
     - name: Run linter

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tests/creds.json
 
 # virtualenv
 env/
+.venv*/
 
 # tox
 .tox/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -87,7 +87,7 @@ Release History
 * Bump isort from 5.11.4 to 5.12.0 by @dependabot in https://github.com/burnash/gspread/pull/1165
 * bump flake8 to 6.0.0 by @alifeee in https://github.com/burnash/gspread/pull/1236
 * merge master into 6.0.0 by @lavigne958 in https://github.com/burnash/gspread/pull/1241
-* Remplace named tuples with enums by @lavigne958 in https://github.com/burnash/gspread/pull/1250
+* Replace named tuples with enums by @lavigne958 in https://github.com/burnash/gspread/pull/1250
 * Feature/add type hints worksheets by @lavigne958 in https://github.com/burnash/gspread/pull/1254
 * Implement hex color conversion by @idonec in https://github.com/burnash/gspread/pull/1270
 * remove lastUpdateTime by @alifeee in https://github.com/burnash/gspread/pull/1295
@@ -413,7 +413,7 @@ ter Christian Clauss <cclauss@me.com> 1630103641 +0200 (#869 by @cclaus)
 
 * fix editor_users_emails - get only from list not all users added to spreadsheet (#939 by @Lukasz)
 
-* add shadow method to get a named range from a speadsheet instance (#941 by @lavigne958)
+* add shadow method to get a named range from a spreadsheet instance (#941 by @lavigne958)
 
 * auto_resize_columns (#948 by @FelipeSantos75)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+6.1.3 (2024-10-04)
+------------------
+
+* ignore jinja CVE by @lavigne958 in https://github.com/burnash/gspread/pull/1481
+* Remove passing exception as args to super in APIError by @mike-flowers-airbnb in https://github.com/burnash/gspread/pull/1477
+* better handler API error parsing. by @lavigne958 in https://github.com/burnash/gspread/pull/1510
+* Add test on receiving an invalid JSON in the APIError exception handler. by @lavigne958 in https://github.com/burnash/gspread/pull/1512
+
 6.1.2 (2024-05-17)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+6.1.4 (2024-10-21)
+------------------
+
+* Full Changelog: https://github.com/burnash/gspread/compare/v6.1.3...v6.1.4
+
 6.1.3 (2024-10-04)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features:
 pip install gspread
 ```
 
-Requirements: Python 3.8+.
+Requirements: Python 3.9+.
 
 ## Basic Usage
 
@@ -53,7 +53,7 @@ wks.format('A1:B1', {'textFormat': {'bold': True}})
 
 ### Upgrade from Python 3.7
 
-Python 3.7 is [end-of-life](https://devguide.python.org/versions/). gspread v6 requires a minimum of Python 3.8.
+Python 3.8 is [end-of-life](https://devguide.python.org/versions/). gspread v6 requires a minimum of Python 3.9.
 
 ### Change `Worksheet.update` arguments
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
 bandit==1.7.10
-black==24.8.0
+black==25.1.0
 codespell==2.2.5
 flake8==7.1.1
 isort==6.0.0

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -3,6 +3,6 @@ black==25.1.0
 codespell==2.2.5
 flake8==7.1.1
 isort==6.0.0
-mypy==1.11.2
+mypy==1.14.1
 mypy-extensions==1.0.0
 typing_extensions==4.12.2

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,4 @@
-bandit==1.7.10
+bandit==1.8.2
 black==25.1.0
 codespell==2.4.1
 flake8==7.1.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -2,7 +2,7 @@ bandit==1.7.10
 black==24.8.0
 codespell==2.2.5
 flake8==7.1.1
-isort==5.12.0
+isort==6.0.0
 mypy==1.11.2
 mypy-extensions==1.0.0
 typing_extensions==4.12.2

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,6 +1,6 @@
 bandit==1.7.10
 black==25.1.0
-codespell==2.2.5
+codespell==2.4.1
 flake8==7.1.1
 isort==6.0.0
 mypy==1.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ keywords = ["spreadsheets", "google-spreadsheets", "google-sheets"]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -28,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = ["google-auth>=1.12.0", "google-auth-oauthlib>=0.4.1"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Office/Business :: Financial :: Spreadsheet",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["google-auth>=1.12.0", "google-auth-oauthlib>=0.4.1"]
+dependencies = ["google-auth>=2.38.0", "google-auth-oauthlib>=1.2.1"]
 requires-python = ">=3.9"
 dynamic = ["version", "description"]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-google-auth==1.12.0
-google-auth-oauthlib==0.4.1
+google-auth==2.38.0
+google-auth-oauthlib==1.2.1
 vcrpy
 pytest
 pytest-vcr
-urllib3==1.26.15
+urllib3==2.3.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 google-auth==2.38.0
 google-auth-oauthlib==1.2.1
-vcrpy
+vcrpy==7.0.0
 pytest
 pytest-vcr
-urllib3==2.3.0
+urllib3==1.26.20; python_version == "3.9"
+urllib3==2.3.0; python_version >= "3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def get_method_name(self_id: str) -> str:
 
 
 def ignore_retry_requests(
-    response: Dict[str, Dict[str, int]]
+    response: Dict[str, Dict[str, int]],
 ) -> Optional[Dict[str, Dict[str, int]]]:
     SKIP_RECORD = [408, 429]
     if response["status"]["code"] in SKIP_RECORD:

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ show-source = True
 statistics = True
 
 [isort]
-extend_skip=.tox,./env
-profile=black
+extend_skip_glob = .tox,./env,.venv*
+profile = black
 
 # Used by the CI to check code format/security
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py39,py310,py311,py312
 skip_missing_interpreters = true
 
 # Used to run tests, **do not** set GS_CREDS_FILENAME to run off-line tests

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ profile = black
 [testenv:lint]
 description = Run code linters
 deps = -r lint-requirements.txt
-commands = black --check --diff --extend-exclude "./env" .
+commands = black --check --diff --color --extend-exclude "./env" .
         codespell --skip=".tox,.git,./docs/build,.mypy_cache,./env" .
         flake8 .
         isort --check-only .

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands = pytest {posargs} tests/
 
 [flake8]
 extend-ignore = E203
-extend-exclude = .tox,./env,./gspread/__init__.py
+extend-exclude = .tox,./env,./gspread/__init__.py,./.venv*
 max-line-length = 255
 max-complexity = 10
 show-source = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312
+envlist = py39,py310,py311,py312,py313
 skip_missing_interpreters = true
 
 # Used to run tests, **do not** set GS_CREDS_FILENAME to run off-line tests


### PR DESCRIPTION
# About This Pull Request

## Main changes

- Add Python 3.12 and 3.13 support
- Drop Python 3.8 because EOL

## Other changes

- Bump `isort` from 5.12.0 to 6.0.0
- Bump `black` from 24.8.0 to 25.1.0
- Bump `mypy` from 1.11.2 to 1.14.1
- Bump `bandit` from 1.7.10 to 1.8.2
- Bump `google-auth` from 1.12.0 to 2.38.0
- Bump `google-auth-oauthlib` from 0.4.1 to 1.2.1

I hope that this PR helps gspread project.
Thanks for reviewing :-)
