### PR TITLE
Include the duplicate column names in error message

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,11 +24,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -U pip
-      - run: pip install -U bandit pyupgrade safety==3.3.1 tox setuptools
+      - run: pip install -U bandit pyupgrade pip-audit tox setuptools
       - run: bandit --recursive --skip B105,B110,B311,B605,B607 --exclude ./.tox .
       - run: tox -e lint
       - run: tox -e py
       - run: shopt -s globstar && pyupgrade --py3-only **/*.py # --py36-plus
-      - run: safety scan -i 42559 -i 62044 -i 67599 -i 70612 # pip version issue, we don't care about it, we don't ship it
+      - run: pip-audit --ignore-vuln PYSEC-2023-228 --ignore-vuln PYSEC-2022-43012 # pip:PYSEC-2023-228 setuptools:PYSEC-2022-43012
       - run: tox -e build
       - run: tox -e doc

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,12 +24,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -U pip
-      - run: pip install -U bandit mypy pyupgrade safety tox setuptools
+      - run: pip install -U bandit pyupgrade safety==3.3.1 tox setuptools
       - run: bandit --recursive --skip B105,B110,B311,B605,B607 --exclude ./.tox .
-        if: ${{ matrix.python >= '3.8' }}
       - run: tox -e lint
       - run: tox -e py
       - run: shopt -s globstar && pyupgrade --py3-only **/*.py # --py36-plus
-      - run: safety check -i 42559 -i 62044 -i 67599 -i 70612 # pip version issue, we don't care about it, we don't ship it
+      - run: safety scan -i 42559 -i 62044 -i 67599 -i 70612 # pip version issue, we don't care about it, we don't ship it
       - run: tox -e build
       - run: tox -e doc

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -8,6 +8,7 @@ This module contains common worksheets' models.
 
 import re
 import warnings
+from collections import Counter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -570,21 +571,24 @@ class Worksheet:
         keys = entire_sheet[head - 1]
         values = entire_sheet[head:]
 
+        def get_dupes(items):
+            counts = Counter(items)
+            return [k for k in keys if counts[k] > 1]
+
         if expected_headers is None:
-            # all headers must be unique
-            header_row_is_unique = len(keys) == len(set(keys))
-            if not header_row_is_unique:
+            duplicates = get_dupes(keys)
+            if duplicates:
                 raise GSpreadException(
-                    "the header row in the worksheet is not unique, "
-                    "try passing 'expected_headers' to get_all_records"
+                    f"the header row in the worksheet contains duplicates: {duplicates}"
+                    "To manually set the header row, use the `expected_headers` "
+                    "parameter of `get_all_records()`"
                 )
         else:
-            # all expected headers must be unique
-            expected_headers_are_unique = len(expected_headers) == len(
-                set(expected_headers)
-            )
-            if not expected_headers_are_unique:
-                raise GSpreadException("the given 'expected_headers' are not uniques")
+            duplicates = get_dupes(expected_headers)
+            if duplicates:
+                raise GSpreadException(
+                    f"the given 'expected_headers' contains duplicates: {duplicates}"
+                )
             # expected headers must be a subset of the actual headers
             if not all(header in keys for header in expected_headers):
                 raise GSpreadException(

--- a/gspread/worksheet.py
+++ b/gspread/worksheet.py
@@ -573,7 +573,7 @@ class Worksheet:
 
         def get_dupes(items):
             counts = Counter(items)
-            return [k for k in keys if counts[k] > 1]
+            return [item for item in counts if counts[item] > 1]
 
         if expected_headers is None:
             duplicates = get_dupes(keys)


### PR DESCRIPTION
When I get this error, I would like to go find the problematic column in the sheet and then fix it. This was difficult before, now it is easy.

Also, fixup the lint action in CI, because I was running into errors:

- We don't need to install mypy (the tox env does that for us)
- We only run this on python versions 3.8+, so the version check isn't needed
- Upgrade the usage of `safety` from the 2.x CLI version to the 3.x version (https://docs.safetycli.com/safety-docs/safety-cli/migrating-from-safety-cli-2.x-to-safety-cli-3.x). Before, we were getting `DEPRECATED: this command (`check`) has been DEPRECATED, and will be unsupported beyond 01 June 2024.` and this caused an error in https://github.com/burnash/gspread/actions/runs/14607328648/job/40978873165?pr=1548
- Pin the version of safety so that this regression doesn't happen again

I can split the CI stuff into a separate PR, but I prefer not to. I can't test the updated CI workflow because I don't have the creds for the `safety` account (and the workflow run, running against my branch, doesn't have access to the creds either). So, I think the only thing to do would be for

1. you @lavigne958 to pull this PR locally and try it using your local creds for `safety`
2. just try merging this to `master` and seeing if it works, then reverting if it doesn't (the YOLO approach ;) )