### PR TITLE
switch safety for pip-audit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,12 +24,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install -U pip
-      - run: pip install -U bandit mypy pyupgrade safety tox setuptools
+      - run: pip install -U bandit mypy pyupgrade pip-audit tox setuptools
       - run: bandit --recursive --skip B105,B110,B311,B605,B607 --exclude ./.tox .
         if: ${{ matrix.python >= '3.8' }}
       - run: tox -e lint
       - run: tox -e py
       - run: shopt -s globstar && pyupgrade --py3-only **/*.py # --py36-plus
-      - run: safety check -i 42559 -i 62044 -i 67599 -i 70612 # pip version issue, we don't care about it, we don't ship it
+      - run: pip-audit --ignore-vuln PYSEC-2023-228 --ignore-vuln PYSEC-2022-43012 # pip:PYSEC-2023-228 setuptools:PYSEC-2022-43012
       - run: tox -e build
       - run: tox -e doc


### PR DESCRIPTION
safetycli was added in https://github.com/burnash/gspread/pull/869

it recently switched to requiring an account -> https://github.com/pyupio/safety/issues/663

![image](https://github.com/user-attachments/assets/7167552d-db35-4772-af88-49375299b8a1)

in order to keep maintenance burden low, I switched it to pip-audit, which seems to do the same thing

I do not think the need for such a step in the CI is not really strong, but I have endeavoured not to "decrease" the security of the project.

this will allow https://github.com/burnash/gspread/pull/1548 to be more easily merged