### PR TITLE
test: change service account to oauth client

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,9 +92,9 @@ gspread uses [vcrpy](https://github.com/kevin1024/vcrpy) to record and replay HT
 
 ### `GS_CREDS_FILENAME` environment variable
 
-You must provide service account credentials using the `GS_CREDS_FILENAME` environment variable in order to make HTTP requests to the Sheets API.
+You must provide OAuth Client credentials using the `GS_CREDS_FILENAME` environment variable in order to make HTTP requests to the Sheets API.
 
-[Obtain service account credentials from Google Developers Console](https://docs.gspread.org/en/latest/oauth2.html#for-bots-using-service-account).
+[Obtain OAuth Client credentials from Google Developers Console](https://docs.gspread.org/en/latest/oauth2.html#for-end-users-using-oauth-client-id).
 
 ### `GS_RECORD_MODE` environment variable
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Generator, Optional, Tuple
 import pytest
 from google.auth.credentials import Credentials
 from google.oauth2.credentials import Credentials as UserCredentials
-from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from requests import Response
 from vcr import VCR
 from vcr.errors import CannotOverwriteExistingCassetteException
@@ -20,7 +19,7 @@ CREDS_FILENAME = os.getenv("GS_CREDS_FILENAME")
 RECORD_MODE = os.getenv("GS_RECORD_MODE", "none")
 
 SCOPE = [
-    "https://spreadsheets.google.com/feeds",
+    "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/drive.file",
 ]
 DUMMY_ACCESS_TOKEN = "<ACCESS_TOKEN>"
@@ -29,7 +28,7 @@ I18N_STR = "Iñtërnâtiônàlizætiøn"  # .encode('utf8')
 
 
 def read_credentials(filename: str) -> Credentials:
-    return ServiceAccountCredentials.from_service_account_file(filename, scopes=SCOPE)
+    return UserCredentials.from_authorized_user_file(filename, scopes=SCOPE)
 
 
 def prefixed_counter(prefix: str, start: int = 1) -> Generator[str, None, None]:


### PR DESCRIPTION
I got hit with
> `The user's Drive storage quota has been exceeded`

when trying to test with a service account created from my `gmail.com` account. Apparently service accounts have 0 Drive storage space available, and I couldn't do any test with `client.create(name)`, since that requires creating a sheet in the service account's Drive.

I tried some workarounds to no avail:
1. Share a folder with the service account with `Editor` permission and do `client.create(name, folder_id=...)`, still fails.
2. Enable domain-wide-delegation so that the service account can impersonate my `gmail.com` account, fails because I cannot login to `admin.google.com` with a `gmail.com` account.

Unless I'm seriously misunderstanding something, the only way for a regular `gmail.com` user to add new tests now is by authenticating with OAuth instead so that test sheets can be created.