### PR TITLE
Fix issue 1594 (test_add_timeout leaks a 1-second timeout into the shared client)

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -165,6 +165,10 @@ class ClientTest(GspreadTest):
         # Once recorded it takes 0.001 seconds to run it, so 1 second should be a large enough value
         timeout = 1
         self.gc.set_timeout(timeout)
+        # the client fixture is module-scoped, restore the default timeout so it
+        # does not leak into the tests that run after this one
+        # this fixes issue #1594
+        self.addCleanup(self.gc.set_timeout, None)
         start = time.time()
         self.spreadsheet.fetch_sheet_metadata()
         end = time.time()


### PR DESCRIPTION
Restore the default timeout when the test test_add_timeout finishes, so it cannot leak into the shared client.

This fixes this issue https://github.com/burnash/gspread/issues/1594

After this change all online tests passed for me.