### PR TITLE
Reset backoff state after non-retryable API errors

### DIFF
--- a/gspread/http_client.py
+++ b/gspread/http_client.py
@@ -618,6 +618,7 @@ class BackOffHTTPClient(HTTPClient):
                 return response
 
             # failed too many times, raise APIEerror
+            self._NR_BACKOFF = 0
             raise err
         except RefreshError as err:
             self._NR_BACKOFF += 1

--- a/gspread/http_client.py
+++ b/gspread/http_client.py
@@ -636,6 +636,7 @@ class BackOffHTTPClient(HTTPClient):
                 return response
 
             # failed too many times, raise APIEerror
+            self._NR_BACKOFF = 0
             raise err
 
 

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -1,9 +1,10 @@
 import datetime
 import json
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from gspread.http_client import HTTPClient
+from gspread.exceptions import APIError
+from gspread.http_client import BackOffHTTPClient, HTTPClient
 from gspread.worksheet import Worksheet
 
 
@@ -101,3 +102,39 @@ class WorksheetForwardsSerializerTest(TestCase):
         worksheet, client = self._make_worksheet()
         worksheet.append_row([1, 2, 3], default_serializer=self.MARKER)
         self.assertIs(client.values_append.call_args.args[4], self.MARKER)
+
+
+class BackOffHTTPClientTest(TestCase):
+    @staticmethod
+    def _error_response(code, domain="global"):
+        response = Mock()
+        response.ok = False
+        response.text = "request failed"
+        response.json.return_value = {
+            "error": {
+                "code": code,
+                "message": "request failed",
+                "errors": [{"domain": domain}],
+            }
+        }
+        return response
+
+    def test_terminal_error_does_not_increase_next_retry_delay(self):
+        session = Mock()
+        success = Mock(ok=True)
+        session.request.side_effect = [
+            self._error_response(403),
+            self._error_response(500),
+            success,
+        ]
+        client = BackOffHTTPClient(auth=None, session=session)
+
+        with self.assertRaises(APIError):
+            client.request("get", "http://example.com/forbidden")
+
+        with patch("gspread.http_client.time.sleep") as sleep:
+            self.assertIs(
+                client.request("get", "http://example.com/retryable"), success
+            )
+
+        sleep.assert_called_once_with(2)


### PR DESCRIPTION
## What changed

A non-retryable API error currently increments `BackOffHTTPClient`'s retry
counter before the error is returned. If the same client later hits a retryable
error, its first delay starts at 4 seconds instead of 2 seconds.

This resets the counter before propagating a terminal API error. The regression
test exercises a 403 -> 500 -> success sequence and verifies that the 500 starts
with the normal 2-second delay.

## Verification

- `tox -e lint,py,build,doc`
- 161 tests passed
- package and Sphinx warning-as-error builds passed
