### PR TITLE
Stop BackOffHTTPClient retrying past the maximum backoff

### DIFF
--- a/gspread/http_client.py
+++ b/gspread/http_client.py
@@ -574,7 +574,6 @@ class BackOffHTTPClient(HTTPClient):
         def _should_retry(
             code: int,
             error: Mapping[str, Any],
-            wait: int,
         ) -> bool:
             # Drive API return a dict object 'errors', the sheet API does not
             if "errors" in error:
@@ -594,7 +593,7 @@ class BackOffHTTPClient(HTTPClient):
             return (
                 code in self._HTTP_ERROR_CODES
                 or code >= HTTPStatus.INTERNAL_SERVER_ERROR
-            ) and wait <= self._MAX_BACKOFF
+            ) and 2**self._NR_BACKOFF <= self._MAX_BACKOFF
 
         try:
             return super().request(*args, **kwargs)
@@ -606,7 +605,7 @@ class BackOffHTTPClient(HTTPClient):
             wait = min(2**self._NR_BACKOFF, self._MAX_BACKOFF)
 
             # check if error should retry
-            if _should_retry(code, error, wait) is True:
+            if _should_retry(code, error) is True:
                 time.sleep(wait)
 
                 # make the request again
@@ -624,7 +623,7 @@ class BackOffHTTPClient(HTTPClient):
             self._NR_BACKOFF += 1
             wait = min(2**self._NR_BACKOFF, self._MAX_BACKOFF)
 
-            if wait <= self._MAX_BACKOFF:
+            if 2**self._NR_BACKOFF <= self._MAX_BACKOFF:
                 time.sleep(wait)
 
                 # make the request again

--- a/gspread/http_client.py
+++ b/gspread/http_client.py
@@ -575,6 +575,10 @@ class BackOffHTTPClient(HTTPClient):
             code: int,
             error: Mapping[str, Any],
         ) -> bool:
+            # Stop retrying once the backoff has grown past the maximum, so a
+            # permanently failing request cannot retry without bound.
+            within_max_backoff = 2**self._NR_BACKOFF <= self._MAX_BACKOFF
+
             # Drive API return a dict object 'errors', the sheet API does not
             if "errors" in error:
                 # Drive API returns a code 403 when reaching quotas/usage limits
@@ -582,7 +586,7 @@ class BackOffHTTPClient(HTTPClient):
                     code == HTTPStatus.FORBIDDEN
                     and error["errors"][0]["domain"] == "usageLimits"
                 ):
-                    return True
+                    return within_max_backoff
 
             # We retry if:
             #   - the return code is one of:
@@ -593,7 +597,7 @@ class BackOffHTTPClient(HTTPClient):
             return (
                 code in self._HTTP_ERROR_CODES
                 or code >= HTTPStatus.INTERNAL_SERVER_ERROR
-            ) and 2**self._NR_BACKOFF <= self._MAX_BACKOFF
+            ) and within_max_backoff
 
         try:
             return super().request(*args, **kwargs)

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -138,3 +138,18 @@ class BackOffHTTPClientTest(TestCase):
             )
 
         sleep.assert_called_once_with(2)
+
+    def test_gives_up_after_max_backoff(self):
+        # A permanently failing retryable request must stop once the backoff
+        # reaches the maximum, instead of retrying without bound.
+        session = Mock()
+        session.request.return_value = self._error_response(429)
+        client = BackOffHTTPClient(auth=None, session=session)
+
+        with patch("gspread.http_client.time.sleep"):
+            with self.assertRaises(APIError):
+                client.request("get", "http://example.com/rate-limited")
+
+        # 2 ** n stops being <= _MAX_BACKOFF (128) once n reaches 8, i.e. after
+        # the initial call plus 7 retries.
+        self.assertEqual(session.request.call_count, 8)

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -153,3 +153,17 @@ class BackOffHTTPClientTest(TestCase):
         # 2 ** n stops being <= _MAX_BACKOFF (128) once n reaches 8, i.e. after
         # the initial call plus 7 retries.
         self.assertEqual(session.request.call_count, 8)
+
+    def test_gives_up_after_max_backoff_on_usage_limits(self):
+        # A 403 usageLimits error is retryable too, so it must also stop once
+        # the backoff reaches the maximum rather than retrying without bound.
+        session = Mock()
+        session.request.return_value = self._error_response(403, domain="usageLimits")
+        client = BackOffHTTPClient(auth=None, session=session)
+
+        with patch("gspread.http_client.time.sleep"):
+            with self.assertRaises(APIError):
+                client.request("get", "http://example.com/usage-limits")
+
+        # Same bound as the other retryable errors: initial call plus 7 retries.
+        self.assertEqual(session.request.call_count, 8)


### PR DESCRIPTION
`BackOffHTTPClient` never stops retrying a persistently failing request.

The retry guard checks `wait <= self._MAX_BACKOFF`, but `wait` is computed as `min(2 ** self._NR_BACKOFF, self._MAX_BACKOFF)`, so it is clamped to `self._MAX_BACKOFF` (128) and the comparison is always true. The comment above it says the intent is to retry only "AND we did not reach the max retry limit" — but that limit check is dead. The same dead guard appears in both the `APIError` and `RefreshError` paths.

So a request that keeps returning 429 / 5xx keeps retrying (each retry is a recursive call) until Python's recursion limit (~1000), sleeping up to 128 s between attempts, instead of giving up after the backoff is exhausted.

Reproduced with a session that always returns 429: the request recurses ~994 times before failing, rather than stopping after ~7 retries.

The fix compares the un-clamped `2 ** self._NR_BACKOFF` against `self._MAX_BACKOFF`, so retries stop once the backoff reaches the maximum (after `_NR_BACKOFF` reaches 8, i.e. the initial call plus 7 retries). The sleep duration still uses the clamped `wait`. With the fix, the same permanently-failing request stops after 8 attempts and raises `APIError`.

The now-unused `wait` parameter of the nested `_should_retry` helper is removed.

Added `test_gives_up_after_max_backoff` (a session that always returns 429 must raise `APIError` after a bounded number of calls); it fails on the current code and passes with the change. Existing `tests/http_client_test.py` passes; `flake8` is clean.
